### PR TITLE
feat: add Coder workspace executor and pool (Phase 2)

### DIFF
--- a/docs/plans/coder-agentic-coding-tasks/progress.md
+++ b/docs/plans/coder-agentic-coding-tasks/progress.md
@@ -4,8 +4,8 @@
 
 | Phase | Status | Updated | Notes |
 |-------|--------|---------|-------|
-| 1. Foundation (Go Module + SQLite Store) | In Review | 2026-02-26 | PR #3 open |
-| 2. Coder Workspace Executor | Not Started | — | — |
+| 1. Foundation (Go Module + SQLite Store) | Complete | 2026-02-27 | Merged PR #3 |
+| 2. Coder Workspace Executor | In Review | 2026-02-27 | PR open |
 | 3. Task Orchestrator | Not Started | — | — |
 | 4. HTTP API | Not Started | — | — |
 | 5. GitHub Integration | Not Started | — | — |
@@ -13,5 +13,6 @@
 | 7. Build, CI/CD + Docker Publishing | Not Started | — | — |
 
 ## Handoff Notes
+- **2026-02-27**: Phase 2 implemented. `internal/coder/` package adds: `Executor` (CLI wrapper for `coder ssh/start/stop/list`), `WorkspaceExecutor` interface for Phase 3, `Pool` (slot-based workspace assignment with `Acquire`/`Release`), sentinel errors, workspace status parsing. 17 tests pass (9 executor via `os/exec` test helper pattern, 7 pool including concurrency, 1 helper). No new dependencies added.
 - **2026-02-26**: Phase 1 implemented and PR #3 opened. Go module initialized with chi/v5, modernc.org/sqlite, google/uuid. Store package has models, embedded migrations, full CRUD (7 methods), and 10 passing tests. `cmd/main.go` serves `/healthz` with graceful shutdown. Ready for Phase 2 (Coder Workspace Executor) after merge.
 - **2026-02-25**: Plan revised to add three details: (1) workspace lifecycle management with `coder list/start/stop` and `--yes` flags in Phases 2+3, (2) `session_id` column in Phase 1 schema with `--session-id`/`--resume` usage in Phase 3 steps, (3) Coder-inspired UI design direction in Phase 6 (Tailwind + shadcn/ui, dark mode, table layout for agents).

--- a/internal/coder/executor.go
+++ b/internal/coder/executor.go
@@ -1,0 +1,167 @@
+package coder
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os/exec"
+)
+
+// CommandCreator is an injectable factory for creating exec.Cmd instances.
+// Defaults to exec.CommandContext; tests inject a fake for deterministic behavior.
+type CommandCreator func(ctx context.Context, name string, args ...string) *exec.Cmd
+
+// SSHResult holds the outcome of a command executed over SSH.
+// A non-nil SSHResult means the command ran (even if it exited non-zero);
+// a nil SSHResult with a non-nil error means the command could not start.
+type SSHResult struct {
+	ExitCode int
+}
+
+// WorkspaceExecutor is consumed by the orchestrator (Phase 3) and enables
+// mock-based testing without a real Coder CLI.
+type WorkspaceExecutor interface {
+	SSH(ctx context.Context, workspace, command string, stdout, stderr io.Writer) (*SSHResult, error)
+	StartWorkspace(ctx context.Context, workspace string) error
+	StopWorkspace(ctx context.Context, workspace string) error
+	ListWorkspaces(ctx context.Context) ([]WorkspaceInfo, error)
+}
+
+// Executor wraps the Coder CLI to manage workspaces and run commands.
+type Executor struct {
+	newCmd CommandCreator
+	logger *slog.Logger
+}
+
+// NewExecutor creates an Executor. If newCmd is nil it defaults to exec.CommandContext.
+func NewExecutor(logger *slog.Logger, newCmd CommandCreator) *Executor {
+	if newCmd == nil {
+		newCmd = exec.CommandContext
+	}
+	return &Executor{newCmd: newCmd, logger: logger}
+}
+
+// SSH runs a command inside a Coder workspace via `coder ssh`.
+// stdout and stderr are streamed to the provided writers in real-time.
+func (e *Executor) SSH(ctx context.Context, workspace, command string, stdout, stderr io.Writer) (*SSHResult, error) {
+	cmd := e.newCmd(ctx, "coder", "ssh", workspace, "--", "bash", "-c", command)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	e.logger.Debug("executing ssh command", "workspace", workspace, "command", command)
+
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return &SSHResult{ExitCode: exitErr.ExitCode()}, fmt.Errorf("command exited with code %d: %w", exitErr.ExitCode(), err)
+		}
+		return nil, fmt.Errorf("ssh exec failed: %w", err)
+	}
+	return &SSHResult{ExitCode: 0}, nil
+}
+
+// StartWorkspace starts a Coder workspace via `coder start --yes`.
+func (e *Executor) StartWorkspace(ctx context.Context, workspace string) error {
+	cmd := e.newCmd(ctx, "coder", "start", workspace, "--yes")
+
+	e.logger.Debug("starting workspace", "workspace", workspace)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("start workspace %q: %s: %w", workspace, string(out), err)
+	}
+	return nil
+}
+
+// StopWorkspace stops a Coder workspace via `coder stop --yes`.
+func (e *Executor) StopWorkspace(ctx context.Context, workspace string) error {
+	cmd := e.newCmd(ctx, "coder", "stop", workspace, "--yes")
+
+	e.logger.Debug("stopping workspace", "workspace", workspace)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("stop workspace %q: %s: %w", workspace, string(out), err)
+	}
+	return nil
+}
+
+// ListWorkspaces returns info about all workspaces via `coder list --output json`.
+func (e *Executor) ListWorkspaces(ctx context.Context) ([]WorkspaceInfo, error) {
+	cmd := e.newCmd(ctx, "coder", "list", "--output", "json")
+
+	e.logger.Debug("listing workspaces")
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("list workspaces: %s: %w", string(out), err)
+	}
+
+	var raw []coderWorkspace
+	if err := json.Unmarshal(out, &raw); err != nil {
+		return nil, fmt.Errorf("parse workspace list: %w", err)
+	}
+
+	infos := make([]WorkspaceInfo, len(raw))
+	for i, w := range raw {
+		infos[i] = WorkspaceInfo{
+			Name:   w.Name,
+			Status: parseWorkspaceStatus(w.LatestBuild.Status),
+		}
+	}
+	return infos, nil
+}
+
+// coderWorkspace mirrors the relevant fields from the Coder CLI JSON output.
+type coderWorkspace struct {
+	Name        string     `json:"name"`
+	LatestBuild coderBuild `json:"latest_build"`
+}
+
+type coderBuild struct {
+	Status string `json:"status"`
+}
+
+// WorkspaceStatus represents the state of a Coder workspace.
+type WorkspaceStatus string
+
+const (
+	WorkspaceStatusRunning   WorkspaceStatus = "running"
+	WorkspaceStatusStopped   WorkspaceStatus = "stopped"
+	WorkspaceStatusFailed    WorkspaceStatus = "failed"
+	WorkspaceStatusStarting  WorkspaceStatus = "starting"
+	WorkspaceStatusStopping  WorkspaceStatus = "stopping"
+	WorkspaceStatusPending   WorkspaceStatus = "pending"
+	WorkspaceStatusCanceling WorkspaceStatus = "canceling"
+	WorkspaceStatusCanceled  WorkspaceStatus = "canceled"
+	WorkspaceStatusDeleting  WorkspaceStatus = "deleting"
+	WorkspaceStatusDeleted   WorkspaceStatus = "deleted"
+	WorkspaceStatusUnknown   WorkspaceStatus = "unknown"
+)
+
+// WorkspaceInfo holds the name and current status of a workspace.
+type WorkspaceInfo struct {
+	Name   string
+	Status WorkspaceStatus
+}
+
+func parseWorkspaceStatus(s string) WorkspaceStatus {
+	switch WorkspaceStatus(s) {
+	case WorkspaceStatusRunning,
+		WorkspaceStatusStopped,
+		WorkspaceStatusFailed,
+		WorkspaceStatusStarting,
+		WorkspaceStatusStopping,
+		WorkspaceStatusPending,
+		WorkspaceStatusCanceling,
+		WorkspaceStatusCanceled,
+		WorkspaceStatusDeleting,
+		WorkspaceStatusDeleted:
+		return WorkspaceStatus(s)
+	default:
+		return WorkspaceStatusUnknown
+	}
+}

--- a/internal/coder/executor_test.go
+++ b/internal/coder/executor_test.go
@@ -1,0 +1,203 @@
+package coder
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"strconv"
+	"testing"
+)
+
+// fakeCommand returns a CommandCreator that re-execs the test binary as a
+// helper process. Extra env vars (e.g. FAKE_STDOUT=hello) control the helper's
+// behavior. This is the standard Go os/exec test pattern.
+func fakeCommand(t *testing.T, env ...string) CommandCreator {
+	t.Helper()
+	return func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		cs := []string{"-test.run=TestHelperProcess", "--", name}
+		cs = append(cs, args...)
+		cmd := exec.CommandContext(ctx, os.Args[0], cs...)
+		cmd.Env = append(os.Environ(), "GO_TEST_HELPER=1")
+		cmd.Env = append(cmd.Env, env...)
+		return cmd
+	}
+}
+
+// TestHelperProcess is invoked by fakeCommand. It is not a real test.
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_TEST_HELPER") != "1" {
+		return
+	}
+
+	if s := os.Getenv("FAKE_STDOUT"); s != "" {
+		fmt.Fprint(os.Stdout, s)
+	}
+	if s := os.Getenv("FAKE_STDERR"); s != "" {
+		fmt.Fprint(os.Stderr, s)
+	}
+
+	code := 0
+	if s := os.Getenv("FAKE_EXIT_CODE"); s != "" {
+		var err error
+		code, err = strconv.Atoi(s)
+		if err != nil {
+			code = 1
+		}
+	}
+	os.Exit(code)
+}
+
+func testExecutor(t *testing.T, env ...string) *Executor {
+	t.Helper()
+	return NewExecutor(slog.Default(), fakeCommand(t, env...))
+}
+
+func TestSSH_Success(t *testing.T) {
+	e := testExecutor(t, "FAKE_STDOUT=hello world")
+
+	var stdout, stderr bytes.Buffer
+	result, err := e.SSH(context.Background(), "ws-1", "echo hello", &stdout, &stderr)
+	if err != nil {
+		t.Fatal("unexpected error:", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", result.ExitCode)
+	}
+	if stdout.String() != "hello world" {
+		t.Fatalf("expected stdout %q, got %q", "hello world", stdout.String())
+	}
+}
+
+func TestSSH_StderrCapture(t *testing.T) {
+	e := testExecutor(t, "FAKE_STDOUT=out", "FAKE_STDERR=err")
+
+	var stdout, stderr bytes.Buffer
+	result, err := e.SSH(context.Background(), "ws-1", "cmd", &stdout, &stderr)
+	if err != nil {
+		t.Fatal("unexpected error:", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", result.ExitCode)
+	}
+	if stdout.String() != "out" {
+		t.Fatalf("expected stdout %q, got %q", "out", stdout.String())
+	}
+	if stderr.String() != "err" {
+		t.Fatalf("expected stderr %q, got %q", "err", stderr.String())
+	}
+}
+
+func TestSSH_NonZeroExit(t *testing.T) {
+	e := testExecutor(t, "FAKE_EXIT_CODE=42", "FAKE_STDERR=fail")
+
+	var stdout, stderr bytes.Buffer
+	result, err := e.SSH(context.Background(), "ws-1", "bad-cmd", &stdout, &stderr)
+	if err == nil {
+		t.Fatal("expected error for non-zero exit")
+	}
+	if result == nil {
+		t.Fatal("expected non-nil SSHResult for non-zero exit")
+	}
+	if result.ExitCode != 42 {
+		t.Fatalf("expected exit code 42, got %d", result.ExitCode)
+	}
+	if stderr.String() != "fail" {
+		t.Fatalf("expected stderr %q, got %q", "fail", stderr.String())
+	}
+}
+
+func TestStartWorkspace(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		e := testExecutor(t)
+		if err := e.StartWorkspace(context.Background(), "ws-1"); err != nil {
+			t.Fatal("unexpected error:", err)
+		}
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		e := testExecutor(t, "FAKE_EXIT_CODE=1", "FAKE_STDERR=workspace not found")
+		err := e.StartWorkspace(context.Background(), "bad-ws")
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if got := err.Error(); got == "" {
+			t.Fatal("expected non-empty error message")
+		}
+	})
+}
+
+func TestStopWorkspace(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		e := testExecutor(t)
+		if err := e.StopWorkspace(context.Background(), "ws-1"); err != nil {
+			t.Fatal("unexpected error:", err)
+		}
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		e := testExecutor(t, "FAKE_EXIT_CODE=1", "FAKE_STDERR=workspace not found")
+		err := e.StopWorkspace(context.Background(), "bad-ws")
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if got := err.Error(); got == "" {
+			t.Fatal("expected non-empty error message")
+		}
+	})
+}
+
+func TestListWorkspaces(t *testing.T) {
+	json := `[{"name":"ws-1","latest_build":{"status":"running"}},{"name":"ws-2","latest_build":{"status":"stopped"}}]`
+	e := testExecutor(t, "FAKE_STDOUT="+json)
+
+	infos, err := e.ListWorkspaces(context.Background())
+	if err != nil {
+		t.Fatal("unexpected error:", err)
+	}
+	if len(infos) != 2 {
+		t.Fatalf("expected 2 workspaces, got %d", len(infos))
+	}
+	if infos[0].Name != "ws-1" || infos[0].Status != WorkspaceStatusRunning {
+		t.Fatalf("unexpected first workspace: %+v", infos[0])
+	}
+	if infos[1].Name != "ws-2" || infos[1].Status != WorkspaceStatusStopped {
+		t.Fatalf("unexpected second workspace: %+v", infos[1])
+	}
+}
+
+func TestListWorkspaces_Empty(t *testing.T) {
+	e := testExecutor(t, "FAKE_STDOUT=[]")
+
+	infos, err := e.ListWorkspaces(context.Background())
+	if err != nil {
+		t.Fatal("unexpected error:", err)
+	}
+	if len(infos) != 0 {
+		t.Fatalf("expected 0 workspaces, got %d", len(infos))
+	}
+}
+
+func TestListWorkspaces_UnknownStatus(t *testing.T) {
+	json := `[{"name":"ws-1","latest_build":{"status":"something_new"}}]`
+	e := testExecutor(t, "FAKE_STDOUT="+json)
+
+	infos, err := e.ListWorkspaces(context.Background())
+	if err != nil {
+		t.Fatal("unexpected error:", err)
+	}
+	if infos[0].Status != WorkspaceStatusUnknown {
+		t.Fatalf("expected WorkspaceStatusUnknown, got %q", infos[0].Status)
+	}
+}
+
+func TestListWorkspaces_InvalidJSON(t *testing.T) {
+	e := testExecutor(t, "FAKE_STDOUT=not json")
+
+	_, err := e.ListWorkspaces(context.Background())
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+}

--- a/internal/coder/workspace.go
+++ b/internal/coder/workspace.go
@@ -1,0 +1,99 @@
+package coder
+
+import (
+	"errors"
+	"sync"
+)
+
+var (
+	ErrNoFreeWorkspace  = errors.New("no free workspace available")
+	ErrWorkspaceNotFound = errors.New("workspace not found")
+	ErrWorkspaceBusy     = errors.New("workspace is busy")
+	ErrWorkspaceNotBusy  = errors.New("workspace is not busy")
+)
+
+// DefaultWorkspaces is the default set of Coder workspace names.
+var DefaultWorkspaces = []string{"agent-1", "agent-2", "agent-3", "agent-4"}
+
+// slot tracks whether a workspace is assigned to a task.
+type slot struct {
+	TaskID string // empty means free
+}
+
+// WorkspaceSlot is the public view of a pool slot, returned by Status().
+type WorkspaceSlot struct {
+	Name   string
+	TaskID string
+}
+
+// Pool manages workspace-to-task assignments. It is purely slot management;
+// starting/stopping workspaces is handled separately by the executor.
+type Pool struct {
+	mu    sync.Mutex
+	slots map[string]*slot
+}
+
+// NewPool creates a Pool with the given workspace names.
+func NewPool(workspaces []string) *Pool {
+	slots := make(map[string]*slot, len(workspaces))
+	for _, name := range workspaces {
+		slots[name] = &slot{}
+	}
+	return &Pool{slots: slots}
+}
+
+// Acquire assigns the first free workspace to the given task and returns its name.
+func (p *Pool) Acquire(taskID string) (string, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	for name, s := range p.slots {
+		if s.TaskID == "" {
+			s.TaskID = taskID
+			return name, nil
+		}
+	}
+	return "", ErrNoFreeWorkspace
+}
+
+// Release frees a workspace so it can be assigned to another task.
+func (p *Pool) Release(workspace string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	s, ok := p.slots[workspace]
+	if !ok {
+		return ErrWorkspaceNotFound
+	}
+	if s.TaskID == "" {
+		return ErrWorkspaceNotBusy
+	}
+	s.TaskID = ""
+	return nil
+}
+
+// Status returns a snapshot of all workspace slots.
+func (p *Pool) Status() []WorkspaceSlot {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	result := make([]WorkspaceSlot, 0, len(p.slots))
+	for name, s := range p.slots {
+		result = append(result, WorkspaceSlot{Name: name, TaskID: s.TaskID})
+	}
+	return result
+}
+
+// FreeCount returns the number of unassigned workspaces.
+func (p *Pool) FreeCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	count := 0
+	for _, s := range p.slots {
+		if s.TaskID == "" {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/coder/workspace_test.go
+++ b/internal/coder/workspace_test.go
@@ -1,0 +1,160 @@
+package coder
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+)
+
+func testPool(t *testing.T) *Pool {
+	t.Helper()
+	return NewPool(DefaultWorkspaces)
+}
+
+func TestPool_AcquireRelease(t *testing.T) {
+	p := testPool(t)
+
+	ws, err := p.Acquire("task-1")
+	if err != nil {
+		t.Fatal("acquire:", err)
+	}
+	if ws == "" {
+		t.Fatal("expected non-empty workspace name")
+	}
+
+	if err := p.Release(ws); err != nil {
+		t.Fatal("release:", err)
+	}
+
+	// Re-acquire should succeed after release
+	ws2, err := p.Acquire("task-2")
+	if err != nil {
+		t.Fatal("re-acquire:", err)
+	}
+	if ws2 == "" {
+		t.Fatal("expected non-empty workspace name after re-acquire")
+	}
+}
+
+func TestPool_AcquireAll(t *testing.T) {
+	p := testPool(t)
+
+	for i := range 4 {
+		_, err := p.Acquire(fmt.Sprintf("task-%d", i))
+		if err != nil {
+			t.Fatalf("acquire %d: %v", i, err)
+		}
+	}
+
+	_, err := p.Acquire("task-overflow")
+	if !errors.Is(err, ErrNoFreeWorkspace) {
+		t.Fatalf("expected ErrNoFreeWorkspace, got %v", err)
+	}
+}
+
+func TestPool_ReleaseUnknown(t *testing.T) {
+	p := testPool(t)
+
+	err := p.Release("nonexistent")
+	if !errors.Is(err, ErrWorkspaceNotFound) {
+		t.Fatalf("expected ErrWorkspaceNotFound, got %v", err)
+	}
+}
+
+func TestPool_ReleaseAlreadyFree(t *testing.T) {
+	p := testPool(t)
+
+	err := p.Release(DefaultWorkspaces[0])
+	if !errors.Is(err, ErrWorkspaceNotBusy) {
+		t.Fatalf("expected ErrWorkspaceNotBusy, got %v", err)
+	}
+}
+
+func TestPool_Status(t *testing.T) {
+	p := testPool(t)
+
+	ws, _ := p.Acquire("task-1")
+
+	status := p.Status()
+	if len(status) != 4 {
+		t.Fatalf("expected 4 slots, got %d", len(status))
+	}
+
+	found := false
+	for _, s := range status {
+		if s.Name == ws {
+			if s.TaskID != "task-1" {
+				t.Fatalf("expected task-1 for %s, got %q", ws, s.TaskID)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("acquired workspace %q not found in status", ws)
+	}
+}
+
+func TestPool_FreeCount(t *testing.T) {
+	p := testPool(t)
+
+	if got := p.FreeCount(); got != 4 {
+		t.Fatalf("expected 4 free, got %d", got)
+	}
+
+	ws, _ := p.Acquire("task-1")
+	if got := p.FreeCount(); got != 3 {
+		t.Fatalf("expected 3 free, got %d", got)
+	}
+
+	p.Release(ws)
+	if got := p.FreeCount(); got != 4 {
+		t.Fatalf("expected 4 free after release, got %d", got)
+	}
+}
+
+func TestPool_ConcurrentAccess(t *testing.T) {
+	p := testPool(t)
+
+	var wg sync.WaitGroup
+	acquired := make(chan string, 4)
+	errs := make(chan error, 8)
+
+	// 8 goroutines competing for 4 slots
+	for i := range 8 {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			ws, err := p.Acquire(fmt.Sprintf("task-%d", id))
+			if err != nil {
+				errs <- err
+				return
+			}
+			acquired <- ws
+		}(i)
+	}
+
+	wg.Wait()
+	close(acquired)
+	close(errs)
+
+	successCount := 0
+	for range acquired {
+		successCount++
+	}
+
+	errCount := 0
+	for err := range errs {
+		if !errors.Is(err, ErrNoFreeWorkspace) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		errCount++
+	}
+
+	if successCount != 4 {
+		t.Fatalf("expected 4 successful acquires, got %d", successCount)
+	}
+	if errCount != 4 {
+		t.Fatalf("expected 4 ErrNoFreeWorkspace errors, got %d", errCount)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `internal/coder/` package with `Executor` — a CLI wrapper that runs commands in Coder workspaces via `coder ssh`, and manages workspace lifecycle (`start`/`stop`/`list`)
- Define `WorkspaceExecutor` interface for Phase 3 orchestrator to consume
- Add `Pool` for workspace-to-task slot management (`Acquire`/`Release`/`Status`/`FreeCount`) with sentinel errors (`ErrNoFreeWorkspace`, `ErrWorkspaceNotFound`, `ErrWorkspaceBusy`, `ErrWorkspaceNotBusy`)
- 17 tests pass including executor tests using standard Go `os/exec` test helper pattern and pool concurrency safety test

## Test plan
- [x] `go build ./...` compiles with no errors
- [x] `go test ./internal/coder/...` — all 17 tests pass
- [x] `go test ./...` — no regressions in store tests
- [ ] Review that `WorkspaceExecutor` interface covers Phase 3 orchestrator needs

🤖 Generated with [Claude Code](https://claude.com/claude-code)