### PR TITLE
feat: add HTTP API with task CRUD, SSE logs, and WebSocket events (Phase 4)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/jcwearn/agent-orchestrator/internal/coder"
 	"github.com/jcwearn/agent-orchestrator/internal/orchestrator"
+	"github.com/jcwearn/agent-orchestrator/internal/server"
 	"github.com/jcwearn/agent-orchestrator/internal/store"
 )
 
@@ -56,12 +57,27 @@ func main() {
 
 	exec := coder.NewExecutor(logger, nil)
 	pool := coder.NewPool(coder.DefaultWorkspaces)
-	orch := orchestrator.New(s, exec, pool, logger, orchestrator.DefaultConfig())
+
+	hub := server.NewHub()
+
+	orchConfig := orchestrator.DefaultConfig()
+	orchConfig.OnEvent = func(taskID, eventType string) {
+		task, err := s.GetTask(ctx, taskID)
+		if err != nil {
+			logger.Error("fetch task for event", "task_id", taskID, "error", err)
+			return
+		}
+		hub.Broadcast(server.Event{Type: eventType, TaskID: taskID, Data: task})
+	}
+
+	orch := orchestrator.New(s, exec, pool, logger, orchConfig)
 	go func() {
 		if err := orch.Run(ctx); err != nil && err != context.Canceled {
 			logger.Error("orchestrator error", "error", err)
 		}
 	}()
+
+	srv := server.New(s, pool, exec, hub, logger)
 
 	r := chi.NewRouter()
 	r.Use(middleware.RequestID)
@@ -80,14 +96,16 @@ func main() {
 		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 	})
 
-	srv := &http.Server{
+	r.Mount("/", srv.Routes())
+
+	httpSrv := &http.Server{
 		Addr:    ":" + port,
 		Handler: r,
 	}
 
 	go func() {
 		logger.Info("server starting", "port", port)
-		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := httpSrv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			logger.Error("server error", "error", err)
 			os.Exit(1)
 		}
@@ -99,7 +117,7 @@ func main() {
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	if err := srv.Shutdown(shutdownCtx); err != nil {
+	if err := httpSrv.Shutdown(shutdownCtx); err != nil {
 		logger.Error("shutdown error", "error", err)
 		os.Exit(1)
 	}

--- a/docs/plans/coder-agentic-coding-tasks/progress.md
+++ b/docs/plans/coder-agentic-coding-tasks/progress.md
@@ -7,12 +7,13 @@
 | 1. Foundation (Go Module + SQLite Store) | Complete | 2026-02-27 | Merged PR #3 |
 | 2. Coder Workspace Executor | In Review | 2026-02-27 | PR open |
 | 3. Task Orchestrator | In Review | 2026-02-27 | PR open |
-| 4. HTTP API | Not Started | — | — |
+| 4. HTTP API | In Review | 2026-02-27 | PR open |
 | 5. GitHub Integration | Not Started | — | — |
 | 6. Embedded Web UI (Vite + React) | Not Started | — | — |
 | 7. Build, CI/CD + Docker Publishing | Not Started | — | — |
 
 ## Handoff Notes
+- **2026-02-27**: Phase 4 implemented. `internal/server/` package adds: `Server` struct with chi router, task CRUD handlers (create/list/get/delete), approval + feedback endpoints, SSE log streaming (500ms poll with `ListTaskLogsSince`), agents endpoint (merges pool slots with Coder workspace status), WebSocket hub (register/unregister/broadcast), and `handleWebSocket` upgrade handler. Added `OnEvent` callback to orchestrator `Config` for bridging status transitions to the WebSocket hub. Added `ListTaskLogsSince` to store. Wired into `cmd/main.go` with hub creation and OnEvent callback. New dependency: `github.com/gorilla/websocket`. 26 server tests + 1 store test pass. Pre-existing flaky `TestMultipleTasksQueueing` exists on main (race condition in goroutine timing).
 - **2026-02-27**: Phase 3 implemented. `internal/orchestrator/` package adds: `Orchestrator` (tick loop with 5s interval), queue helpers (FIFO via ListTasks DESC), 2-step lifecycle (plan → awaiting_approval → implement → complete), `logWriter` (line-splitting log persistence), crash recovery (`recoverActiveTasks`), workspace release during approval wait. Wired into `cmd/main.go` with signal-notified context. 14 tests pass (mock executor, in-memory SQLite). No new dependencies.
 - **2026-02-27**: Phase 2 implemented. `internal/coder/` package adds: `Executor` (CLI wrapper for `coder ssh/start/stop/list`), `WorkspaceExecutor` interface for Phase 3, `Pool` (slot-based workspace assignment with `Acquire`/`Release`), sentinel errors, workspace status parsing. 17 tests pass (9 executor via `os/exec` test helper pattern, 7 pool including concurrency, 1 helper). No new dependencies added.
 - **2026-02-26**: Phase 1 implemented and PR #3 opened. Go module initialized with chi/v5, modernc.org/sqlite, google/uuid. Store package has models, embedded migrations, full CRUD (7 methods), and 10 passing tests. `cmd/main.go` serves `/healthz` with graceful shutdown. Ready for Phase 2 (Coder Workspace Executor) after merge.

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 
 require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17k
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -13,6 +13,7 @@ import (
 // Config holds orchestrator settings.
 type Config struct {
 	TickInterval time.Duration
+	OnEvent      func(taskID, eventType string)
 }
 
 // DefaultConfig returns sensible defaults: 5-second tick interval.
@@ -118,6 +119,12 @@ func (o *Orchestrator) processApprovedTasks(ctx context.Context) error {
 	return nil
 }
 
+func (o *Orchestrator) publishEvent(taskID, eventType string) {
+	if o.config.OnEvent != nil {
+		o.config.OnEvent(taskID, eventType)
+	}
+}
+
 // runTask drives a task through the planning step. On success, the task moves
 // to awaiting_approval and the workspace is released.
 func (o *Orchestrator) runTask(ctx context.Context, task *store.Task, workspace string) {
@@ -133,6 +140,7 @@ func (o *Orchestrator) runTask(ctx context.Context, task *store.Task, workspace 
 		o.stopAndRelease(ctx, workspace)
 		return
 	}
+	o.publishEvent(task.ID, "task.updated")
 
 	if err := o.startWorkspace(ctx, task, workspace); err != nil {
 		o.failTask(ctx, task, workspace, err)
@@ -149,6 +157,7 @@ func (o *Orchestrator) runTask(ctx context.Context, task *store.Task, workspace 
 	if err := o.store.UpdateTask(ctx, task.ID, task); err != nil {
 		o.logger.Error("update task to awaiting_approval", "task_id", task.ID, "error", err)
 	}
+	o.publishEvent(task.ID, "task.updated")
 	o.stopAndRelease(ctx, workspace)
 	o.logger.Info("task plan complete, awaiting approval", "task_id", task.ID)
 }
@@ -166,6 +175,7 @@ func (o *Orchestrator) runImplement(ctx context.Context, task *store.Task, works
 		o.stopAndRelease(ctx, workspace)
 		return
 	}
+	o.publishEvent(task.ID, "task.updated")
 
 	if err := o.startWorkspace(ctx, task, workspace); err != nil {
 		o.failTask(ctx, task, workspace, err)
@@ -183,6 +193,7 @@ func (o *Orchestrator) runImplement(ctx context.Context, task *store.Task, works
 	if err := o.store.UpdateTask(ctx, task.ID, task); err != nil {
 		o.logger.Error("update task to complete", "task_id", task.ID, "error", err)
 	}
+	o.publishEvent(task.ID, "task.updated")
 	o.stopAndRelease(ctx, workspace)
 	o.logger.Info("task complete", "task_id", task.ID)
 }

--- a/internal/orchestrator/steps.go
+++ b/internal/orchestrator/steps.go
@@ -105,6 +105,7 @@ func (o *Orchestrator) failTask(ctx context.Context, task *store.Task, workspace
 	if err := o.store.UpdateTask(ctx, task.ID, task); err != nil {
 		o.logger.Error("update failed task", "task_id", task.ID, "error", err)
 	}
+	o.publishEvent(task.ID, "task.updated")
 	o.stopAndRelease(ctx, workspace)
 }
 

--- a/internal/server/handlers_agents.go
+++ b/internal/server/handlers_agents.go
@@ -1,0 +1,36 @@
+package server
+
+import (
+	"net/http"
+)
+
+type AgentInfo struct {
+	Name            string `json:"name"`
+	TaskID          string `json:"task_id"`
+	WorkspaceStatus string `json:"workspace_status"`
+}
+
+func (s *Server) handleListAgents(w http.ResponseWriter, r *http.Request) {
+	slots := s.pool.Status()
+
+	statusMap := make(map[string]string)
+	workspaces, err := s.executor.ListWorkspaces(r.Context())
+	if err != nil {
+		s.logger.Warn("list workspaces for agents", "error", err)
+	} else {
+		for _, ws := range workspaces {
+			statusMap[ws.Name] = string(ws.Status)
+		}
+	}
+
+	agents := make([]AgentInfo, 0, len(slots))
+	for _, slot := range slots {
+		agents = append(agents, AgentInfo{
+			Name:            slot.Name,
+			TaskID:          slot.TaskID,
+			WorkspaceStatus: statusMap[slot.Name],
+		})
+	}
+
+	writeJSON(w, http.StatusOK, agents)
+}

--- a/internal/server/handlers_logs.go
+++ b/internal/server/handlers_logs.go
@@ -1,0 +1,92 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jcwearn/agent-orchestrator/internal/store"
+)
+
+func (s *Server) handleStreamLogs(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	task, err := s.store.GetTask(r.Context(), id)
+	if errors.Is(err, store.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "task not found")
+		return
+	}
+	if err != nil {
+		s.logger.Error("get task for logs", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeError(w, http.StatusInternalServerError, "streaming not supported")
+		return
+	}
+
+	lastID := 0
+
+	// If task is already terminal, send all logs and done immediately.
+	if isTerminal(task.Status) {
+		s.flushLogs(r.Context(), w, flusher, id, &lastID)
+		fmt.Fprintf(w, "event: done\ndata: {}\n\n")
+		flusher.Flush()
+		return
+	}
+
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-ticker.C:
+			s.flushLogs(r.Context(), w, flusher, id, &lastID)
+
+			task, err = s.store.GetTask(r.Context(), id)
+			if err != nil {
+				return
+			}
+			if isTerminal(task.Status) {
+				s.flushLogs(r.Context(), w, flusher, id, &lastID)
+				fmt.Fprintf(w, "event: done\ndata: {}\n\n")
+				flusher.Flush()
+				return
+			}
+		}
+	}
+}
+
+func (s *Server) flushLogs(ctx context.Context, w http.ResponseWriter, flusher http.Flusher, taskID string, lastID *int) {
+	logs, err := s.store.ListTaskLogsSince(ctx, taskID, *lastID)
+	if err != nil {
+		s.logger.Error("list logs since", "error", err)
+		return
+	}
+
+	for _, l := range logs {
+		data, _ := json.Marshal(l)
+		fmt.Fprintf(w, "data: %s\n\n", data)
+		*lastID = l.ID
+	}
+	if len(logs) > 0 {
+		flusher.Flush()
+	}
+}
+
+func isTerminal(status string) bool {
+	return status == "complete" || status == "failed"
+}

--- a/internal/server/handlers_tasks.go
+++ b/internal/server/handlers_tasks.go
@@ -1,0 +1,181 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/jcwearn/agent-orchestrator/internal/store"
+)
+
+type CreateTaskRequest struct {
+	Prompt     string `json:"prompt"`
+	RepoURL    string `json:"repo_url"`
+	BaseBranch string `json:"base_branch"`
+}
+
+type FeedbackRequest struct {
+	Feedback string `json:"feedback"`
+}
+
+func (s *Server) handleCreateTask(w http.ResponseWriter, r *http.Request) {
+	var req CreateTaskRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if req.Prompt == "" {
+		writeError(w, http.StatusBadRequest, "prompt is required")
+		return
+	}
+	if req.RepoURL == "" {
+		writeError(w, http.StatusBadRequest, "repo_url is required")
+		return
+	}
+	if req.BaseBranch == "" {
+		req.BaseBranch = "main"
+	}
+
+	task := &store.Task{
+		Prompt:     req.Prompt,
+		RepoURL:    req.RepoURL,
+		BaseBranch: req.BaseBranch,
+		SourceType: "api",
+		SessionID:  uuid.New().String(),
+	}
+
+	if err := s.store.CreateTask(r.Context(), task); err != nil {
+		s.logger.Error("create task", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+
+	s.hub.Broadcast(Event{Type: "task.created", TaskID: task.ID, Data: task})
+	writeJSON(w, http.StatusCreated, task)
+}
+
+func (s *Server) handleListTasks(w http.ResponseWriter, r *http.Request) {
+	status := r.URL.Query().Get("status")
+
+	tasks, err := s.store.ListTasks(r.Context(), status)
+	if err != nil {
+		s.logger.Error("list tasks", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+
+	if tasks == nil {
+		tasks = []store.Task{}
+	}
+	writeJSON(w, http.StatusOK, tasks)
+}
+
+func (s *Server) handleGetTask(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	task, err := s.store.GetTask(r.Context(), id)
+	if errors.Is(err, store.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "task not found")
+		return
+	}
+	if err != nil {
+		s.logger.Error("get task", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, task)
+}
+
+func (s *Server) handleDeleteTask(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	err := s.store.DeleteTask(r.Context(), id)
+	if errors.Is(err, store.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "task not found")
+		return
+	}
+	if err != nil {
+		s.logger.Error("delete task", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+
+	s.hub.Broadcast(Event{Type: "task.deleted", TaskID: id})
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) handleApproveTask(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	task, err := s.store.GetTask(r.Context(), id)
+	if errors.Is(err, store.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "task not found")
+		return
+	}
+	if err != nil {
+		s.logger.Error("get task for approve", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+
+	if task.Status != "awaiting_approval" {
+		writeError(w, http.StatusConflict, "task is not awaiting approval")
+		return
+	}
+
+	task.PlanFeedback = ptr("approved")
+	if err := s.store.UpdateTask(r.Context(), task.ID, task); err != nil {
+		s.logger.Error("approve task", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+
+	s.hub.Broadcast(Event{Type: "task.updated", TaskID: task.ID, Data: task})
+	writeJSON(w, http.StatusOK, task)
+}
+
+func (s *Server) handleFeedbackTask(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	var req FeedbackRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if req.Feedback == "" {
+		writeError(w, http.StatusBadRequest, "feedback is required")
+		return
+	}
+
+	task, err := s.store.GetTask(r.Context(), id)
+	if errors.Is(err, store.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "task not found")
+		return
+	}
+	if err != nil {
+		s.logger.Error("get task for feedback", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+
+	if task.Status != "awaiting_approval" {
+		writeError(w, http.StatusConflict, "task is not awaiting approval")
+		return
+	}
+
+	task.PlanFeedback = &req.Feedback
+	task.PlanRevision++
+	if err := s.store.UpdateTask(r.Context(), task.ID, task); err != nil {
+		s.logger.Error("feedback task", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+
+	s.hub.Broadcast(Event{Type: "task.updated", TaskID: task.ID, Data: task})
+	writeJSON(w, http.StatusOK, task)
+}

--- a/internal/server/hub.go
+++ b/internal/server/hub.go
@@ -1,0 +1,55 @@
+package server
+
+import (
+	"encoding/json"
+	"sync"
+
+	"github.com/gorilla/websocket"
+)
+
+type Event struct {
+	Type   string `json:"type"`
+	TaskID string `json:"task_id"`
+	Data   any    `json:"data,omitempty"`
+}
+
+type Hub struct {
+	mu    sync.Mutex
+	conns map[*websocket.Conn]struct{}
+}
+
+func NewHub() *Hub {
+	return &Hub{
+		conns: make(map[*websocket.Conn]struct{}),
+	}
+}
+
+func (h *Hub) Register(conn *websocket.Conn) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.conns[conn] = struct{}{}
+}
+
+func (h *Hub) Unregister(conn *websocket.Conn) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	delete(h.conns, conn)
+	conn.Close()
+}
+
+func (h *Hub) Broadcast(event Event) {
+	data, err := json.Marshal(event)
+	if err != nil {
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	for conn := range h.conns {
+		if err := conn.WriteMessage(websocket.TextMessage, data); err != nil {
+			conn.Close()
+			delete(h.conns, conn)
+		}
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,0 +1,63 @@
+package server
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jcwearn/agent-orchestrator/internal/coder"
+	"github.com/jcwearn/agent-orchestrator/internal/store"
+)
+
+type Server struct {
+	store    *store.Store
+	pool     *coder.Pool
+	executor coder.WorkspaceExecutor
+	hub      *Hub
+	logger   *slog.Logger
+}
+
+func New(store *store.Store, pool *coder.Pool, executor coder.WorkspaceExecutor, hub *Hub, logger *slog.Logger) *Server {
+	return &Server{
+		store:    store,
+		pool:     pool,
+		executor: executor,
+		hub:      hub,
+		logger:   logger,
+	}
+}
+
+func (s *Server) Routes() chi.Router {
+	r := chi.NewRouter()
+
+	r.Route("/api/v1", func(r chi.Router) {
+		r.Post("/tasks", s.handleCreateTask)
+		r.Get("/tasks", s.handleListTasks)
+		r.Get("/tasks/{id}", s.handleGetTask)
+		r.Delete("/tasks/{id}", s.handleDeleteTask)
+		r.Post("/tasks/{id}/approve", s.handleApproveTask)
+		r.Post("/tasks/{id}/feedback", s.handleFeedbackTask)
+		r.Get("/tasks/{id}/logs", s.handleStreamLogs)
+
+		r.Get("/agents", s.handleListAgents)
+
+		r.Get("/ws", s.handleWebSocket)
+	})
+
+	return r
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(v)
+}
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]string{"error": msg})
+}
+
+func ptr(s string) *string {
+	return &s
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,754 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/jcwearn/agent-orchestrator/internal/coder"
+	"github.com/jcwearn/agent-orchestrator/internal/store"
+)
+
+// --- test helpers ---
+
+type mockExecutor struct {
+	workspaces []coder.WorkspaceInfo
+	err        error
+}
+
+func (m *mockExecutor) SSH(ctx context.Context, workspace, command string, stdout, stderr io.Writer) (*coder.SSHResult, error) {
+	return &coder.SSHResult{ExitCode: 0}, nil
+}
+
+func (m *mockExecutor) StartWorkspace(ctx context.Context, workspace string, params map[string]string) error {
+	return nil
+}
+
+func (m *mockExecutor) StopWorkspace(ctx context.Context, workspace string) error {
+	return nil
+}
+
+func (m *mockExecutor) ListWorkspaces(ctx context.Context) ([]coder.WorkspaceInfo, error) {
+	return m.workspaces, m.err
+}
+
+func testStore(t *testing.T) *store.Store {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:?_pragma=foreign_keys(1)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { db.Close() })
+
+	s := store.New(db, slog.Default())
+	if err := s.RunMigrations(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+func testServer(t *testing.T) (*Server, *store.Store) {
+	t.Helper()
+	s := testStore(t)
+	pool := coder.NewPool([]string{"agent-1", "agent-2"})
+	exec := &mockExecutor{}
+	hub := NewHub()
+	srv := New(s, pool, exec, hub, slog.Default())
+	return srv, s
+}
+
+func testServerWithExecutor(t *testing.T, exec coder.WorkspaceExecutor) (*Server, *store.Store) {
+	t.Helper()
+	s := testStore(t)
+	pool := coder.NewPool([]string{"agent-1", "agent-2"})
+	hub := NewHub()
+	srv := New(s, pool, exec, hub, slog.Default())
+	return srv, s
+}
+
+func createTask(t *testing.T, s *store.Store, prompt string) *store.Task {
+	t.Helper()
+	task := &store.Task{
+		Prompt:     prompt,
+		RepoURL:    "https://github.com/test/repo",
+		SourceType: "api",
+		SessionID:  "session-123",
+	}
+	if err := s.CreateTask(context.Background(), task); err != nil {
+		t.Fatal(err)
+	}
+	return task
+}
+
+// --- task CRUD tests ---
+
+func TestCreateTask_Success(t *testing.T) {
+	srv, _ := testServer(t)
+	ts := httptest.NewServer(srv.Routes())
+	defer ts.Close()
+
+	body := `{"prompt": "implement feature X", "repo_url": "https://github.com/test/repo"}`
+	resp, err := http.Post(ts.URL+"/api/v1/tasks", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", resp.StatusCode)
+	}
+
+	var task store.Task
+	if err := json.NewDecoder(resp.Body).Decode(&task); err != nil {
+		t.Fatal(err)
+	}
+	if task.ID == "" {
+		t.Fatal("expected task ID")
+	}
+	if task.Status != "queued" {
+		t.Fatalf("expected status 'queued', got %q", task.Status)
+	}
+	if task.BaseBranch != "main" {
+		t.Fatalf("expected base_branch 'main', got %q", task.BaseBranch)
+	}
+	if task.SourceType != "api" {
+		t.Fatalf("expected source_type 'api', got %q", task.SourceType)
+	}
+	if task.SessionID == "" {
+		t.Fatal("expected session_id to be set")
+	}
+}
+
+func TestCreateTask_CustomBaseBranch(t *testing.T) {
+	srv, _ := testServer(t)
+	ts := httptest.NewServer(srv.Routes())
+	defer ts.Close()
+
+	body := `{"prompt": "fix bug", "repo_url": "https://github.com/test/repo", "base_branch": "develop"}`
+	resp, err := http.Post(ts.URL+"/api/v1/tasks", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", resp.StatusCode)
+	}
+
+	var task store.Task
+	json.NewDecoder(resp.Body).Decode(&task)
+	if task.BaseBranch != "develop" {
+		t.Fatalf("expected base_branch 'develop', got %q", task.BaseBranch)
+	}
+}
+
+func TestCreateTask_MissingPrompt(t *testing.T) {
+	srv, _ := testServer(t)
+	ts := httptest.NewServer(srv.Routes())
+	defer ts.Close()
+
+	body := `{"repo_url": "https://github.com/test/repo"}`
+	resp, err := http.Post(ts.URL+"/api/v1/tasks", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestCreateTask_MissingRepoURL(t *testing.T) {
+	srv, _ := testServer(t)
+	ts := httptest.NewServer(srv.Routes())
+	defer ts.Close()
+
+	body := `{"prompt": "do something"}`
+	resp, err := http.Post(ts.URL+"/api/v1/tasks", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestListTasks_Empty(t *testing.T) {
+	srv, _ := testServer(t)
+	ts := httptest.NewServer(srv.Routes())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/api/v1/tasks")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var tasks []store.Task
+	json.NewDecoder(resp.Body).Decode(&tasks)
+	if len(tasks) != 0 {
+		t.Fatalf("expected empty list, got %d", len(tasks))
+	}
+}
+
+func TestListTasks_All(t *testing.T) {
+	srv, s := testServer(t)
+	ts := httptest.NewServer(srv.Routes())
+	defer ts.Close()
+
+	createTask(t, s, "task-1")
+	createTask(t, s, "task-2")
+
+	resp, err := http.Get(ts.URL + "/api/v1/tasks")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	var tasks []store.Task
+	json.NewDecoder(resp.Body).Decode(&tasks)
+	if len(tasks) != 2 {
+		t.Fatalf("expected 2 tasks, got %d", len(tasks))
+	}
+}
+
+func TestListTasks_Filtered(t *testing.T) {
+	srv, s := testServer(t)
+	ts := httptest.NewServer(srv.Routes())
+	defer ts.Close()
+
+	createTask(t, s, "task-1")
+	task2 := createTask(t, s, "task-2")
+	task2.Status = "planning"
+	s.UpdateTask(context.Background(), task2.ID, task2)
+
+	resp, err := http.Get(ts.URL + "/api/v1/tasks?status=queued")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	var tasks []store.Task
+	json.NewDecoder(resp.Body).Decode(&tasks)
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 queued task, got %d", len(tasks))
+	}
+}
+
+func TestGetTask_Success(t *testing.T) {
+	srv, s := testServer(t)
+	ts := httptest.NewServer(srv.Routes())
+	defer ts.Close()
+
+	task := createTask(t, s, "get me")
+
+	resp, err := http.Get(ts.URL + "/api/v1/tasks/" + task.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var got store.Task
+	json.NewDecoder(resp.Body).Decode(&got)
+	if got.Prompt != "get me" {
+		t.Fatalf("expected prompt 'get me', got %q", got.Prompt)
+	}
+}
+
+func TestGetTask_NotFound(t *testing.T) {
+	srv, _ := testServer(t)
+	ts := httptest.NewServer(srv.Routes())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/api/v1/tasks/nonexistent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestDeleteTask_Success(t *testing.T) {
+	srv, s := testServer(t)
+	ts := httptest.NewServer(srv.Routes())
+	defer ts.Close()
+
+	task := createTask(t, s, "delete me")
+
+	req, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/tasks/"+task.ID, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", resp.StatusCode)
+	}
+}
+
+func TestDeleteTask_NotFound(t *testing.T) {
+	srv, _ := testServer(t)
+	ts := httptest.NewServer(srv.Routes())
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/tasks/nonexistent", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+// --- approve tests ---
+
+func TestApproveTask_Success(t *testing.T) {
+	srv, s := testServer(t)
+	ts := httptest.NewServer(srv.Routes())
+	defer ts.Close()
+
+	task := createTask(t, s, "approve me")
+	task.Status = "awaiting_approval"
+	plan := "the plan"
+	task.Plan = &plan
+	s.UpdateTask(context.Background(), task.ID, task)
+
+	resp, err := http.Post(ts.URL+"/api/v1/tasks/"+task.ID+"/approve", "application/json", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var updated store.Task
+	json.NewDecoder(resp.Body).Decode(&updated)
+	if updated.PlanFeedback == nil || *updated.PlanFeedback != "approved" {
+		t.Fatal("expected plan_feedback to be 'approved'")
+	}
+}
+
+func TestApproveTask_WrongStatus(t *testing.T) {
+	srv, s := testServer(t)
+	ts := httptest.NewServer(srv.Routes())
+	defer ts.Close()
+
+	task := createTask(t, s, "not ready")
+
+	resp, err := http.Post(ts.URL+"/api/v1/tasks/"+task.ID+"/approve", "application/json", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("expected 409, got %d", resp.StatusCode)
+	}
+}
+
+func TestApproveTask_NotFound(t *testing.T) {
+	srv, _ := testServer(t)
+	ts := httptest.NewServer(srv.Routes())
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/api/v1/tasks/nonexistent/approve", "application/json", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+// --- feedback tests ---
+
+func TestFeedbackTask_Success(t *testing.T) {
+	srv, s := testServer(t)
+	ts := httptest.NewServer(srv.Routes())
+	defer ts.Close()
+
+	task := createTask(t, s, "feedback me")
+	task.Status = "awaiting_approval"
+	plan := "the plan"
+	task.Plan = &plan
+	s.UpdateTask(context.Background(), task.ID, task)
+
+	body := `{"feedback": "please add error handling"}`
+	resp, err := http.Post(ts.URL+"/api/v1/tasks/"+task.ID+"/feedback", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var updated store.Task
+	json.NewDecoder(resp.Body).Decode(&updated)
+	if updated.PlanFeedback == nil || *updated.PlanFeedback != "please add error handling" {
+		t.Fatal("expected plan_feedback to be set")
+	}
+	if updated.PlanRevision != 1 {
+		t.Fatalf("expected plan_revision 1, got %d", updated.PlanRevision)
+	}
+}
+
+func TestFeedbackTask_EmptyFeedback(t *testing.T) {
+	srv, s := testServer(t)
+	ts := httptest.NewServer(srv.Routes())
+	defer ts.Close()
+
+	task := createTask(t, s, "feedback me")
+	task.Status = "awaiting_approval"
+	s.UpdateTask(context.Background(), task.ID, task)
+
+	body := `{"feedback": ""}`
+	resp, err := http.Post(ts.URL+"/api/v1/tasks/"+task.ID+"/feedback", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestFeedbackTask_WrongStatus(t *testing.T) {
+	srv, s := testServer(t)
+	ts := httptest.NewServer(srv.Routes())
+	defer ts.Close()
+
+	task := createTask(t, s, "not ready")
+
+	body := `{"feedback": "some feedback"}`
+	resp, err := http.Post(ts.URL+"/api/v1/tasks/"+task.ID+"/feedback", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("expected 409, got %d", resp.StatusCode)
+	}
+}
+
+// --- SSE logs test ---
+
+func TestStreamLogs(t *testing.T) {
+	srv, s := testServer(t)
+	ts := httptest.NewServer(srv.Routes())
+	defer ts.Close()
+
+	task := createTask(t, s, "log task")
+	task.Status = "complete"
+	s.UpdateTask(context.Background(), task.ID, task)
+
+	// Add some logs.
+	for _, line := range []string{"line 1", "line 2"} {
+		s.CreateTaskLog(context.Background(), &store.TaskLog{
+			TaskID: task.ID, Step: "plan", Stream: "stdout", Line: line,
+		})
+	}
+
+	resp, err := http.Get(ts.URL + "/api/v1/tasks/" + task.ID + "/logs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.Header.Get("Content-Type") != "text/event-stream" {
+		t.Fatalf("expected text/event-stream, got %q", resp.Header.Get("Content-Type"))
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	content := string(body)
+
+	if !strings.Contains(content, "data: ") {
+		t.Fatal("expected data: lines in SSE stream")
+	}
+	if !strings.Contains(content, "event: done") {
+		t.Fatal("expected done event in SSE stream")
+	}
+	if !strings.Contains(content, "line 1") {
+		t.Fatal("expected 'line 1' in SSE stream")
+	}
+	if !strings.Contains(content, "line 2") {
+		t.Fatal("expected 'line 2' in SSE stream")
+	}
+}
+
+func TestStreamLogs_NotFound(t *testing.T) {
+	srv, _ := testServer(t)
+	ts := httptest.NewServer(srv.Routes())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/api/v1/tasks/nonexistent/logs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestStreamLogs_ActiveTask(t *testing.T) {
+	srv, s := testServer(t)
+	ts := httptest.NewServer(srv.Routes())
+	defer ts.Close()
+
+	task := createTask(t, s, "active task")
+	task.Status = "planning"
+	s.UpdateTask(context.Background(), task.ID, task)
+
+	// Add a log.
+	s.CreateTaskLog(context.Background(), &store.TaskLog{
+		TaskID: task.ID, Step: "plan", Stream: "stdout", Line: "line 1",
+	})
+
+	// Start SSE connection with timeout.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/api/v1/tasks/"+task.ID+"/logs", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	// Read partial output - should get some data lines.
+	buf := make([]byte, 4096)
+	n, _ := resp.Body.Read(buf)
+	content := string(buf[:n])
+
+	if !strings.Contains(content, "data: ") {
+		t.Fatal("expected data: lines in SSE stream")
+	}
+
+	// Mark task as complete so the SSE endpoint closes.
+	task.Status = "complete"
+	s.UpdateTask(context.Background(), task.ID, task)
+
+	// Read remaining output.
+	remaining, _ := io.ReadAll(resp.Body)
+	content += string(remaining)
+
+	if !strings.Contains(content, "event: done") {
+		t.Fatal("expected done event after task completion")
+	}
+}
+
+// --- agents test ---
+
+func TestListAgents(t *testing.T) {
+	exec := &mockExecutor{
+		workspaces: []coder.WorkspaceInfo{
+			{Name: "agent-1", Status: coder.WorkspaceStatusRunning},
+			{Name: "agent-2", Status: coder.WorkspaceStatusStopped},
+		},
+	}
+	srv, _ := testServerWithExecutor(t, exec)
+	ts := httptest.NewServer(srv.Routes())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/api/v1/agents")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var agents []AgentInfo
+	json.NewDecoder(resp.Body).Decode(&agents)
+	if len(agents) != 2 {
+		t.Fatalf("expected 2 agents, got %d", len(agents))
+	}
+
+	// Find agent-1 and verify workspace status is merged.
+	statusMap := make(map[string]string)
+	for _, a := range agents {
+		statusMap[a.Name] = a.WorkspaceStatus
+	}
+	if statusMap["agent-1"] != "running" {
+		t.Fatalf("expected agent-1 status 'running', got %q", statusMap["agent-1"])
+	}
+	if statusMap["agent-2"] != "stopped" {
+		t.Fatalf("expected agent-2 status 'stopped', got %q", statusMap["agent-2"])
+	}
+}
+
+func TestListAgents_ExecutorError(t *testing.T) {
+	exec := &mockExecutor{
+		err: io.ErrUnexpectedEOF,
+	}
+	srv, _ := testServerWithExecutor(t, exec)
+	ts := httptest.NewServer(srv.Routes())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/api/v1/agents")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 (graceful degradation), got %d", resp.StatusCode)
+	}
+
+	var agents []AgentInfo
+	json.NewDecoder(resp.Body).Decode(&agents)
+	// Should still return pool slots, just without workspace status.
+	if len(agents) != 2 {
+		t.Fatalf("expected 2 agents, got %d", len(agents))
+	}
+}
+
+// --- hub tests ---
+
+func TestHub_RegisterBroadcastUnregister(t *testing.T) {
+	hub := NewHub()
+
+	// Start a test websocket server.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		hub.Register(conn)
+	}))
+	defer ts.Close()
+
+	// Connect a client.
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	// Give the server a moment to register.
+	time.Sleep(50 * time.Millisecond)
+
+	// Broadcast an event.
+	hub.Broadcast(Event{Type: "task.created", TaskID: "test-123"})
+
+	// Read the message from client.
+	conn.SetReadDeadline(time.Now().Add(time.Second))
+	_, msg, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var event Event
+	if err := json.Unmarshal(msg, &event); err != nil {
+		t.Fatal(err)
+	}
+	if event.Type != "task.created" {
+		t.Fatalf("expected type 'task.created', got %q", event.Type)
+	}
+	if event.TaskID != "test-123" {
+		t.Fatalf("expected task_id 'test-123', got %q", event.TaskID)
+	}
+
+	// Unregister and verify broadcast doesn't fail.
+	hub.Unregister(conn)
+	hub.Broadcast(Event{Type: "task.updated", TaskID: "test-456"})
+}
+
+func TestHub_BroadcastNoConnections(t *testing.T) {
+	hub := NewHub()
+	// Should not panic.
+	hub.Broadcast(Event{Type: "task.created", TaskID: "test"})
+}
+
+// --- websocket handler test ---
+
+func TestWebSocket_Handler(t *testing.T) {
+	srv, _ := testServer(t)
+	ts := httptest.NewServer(srv.Routes())
+	defer ts.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/api/v1/ws"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	// Give the server a moment to register the connection.
+	time.Sleep(50 * time.Millisecond)
+
+	// Broadcast via hub.
+	srv.hub.Broadcast(Event{Type: "task.updated", TaskID: "ws-test"})
+
+	// Read message.
+	conn.SetReadDeadline(time.Now().Add(time.Second))
+	_, msg, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var event Event
+	json.Unmarshal(msg, &event)
+	if event.Type != "task.updated" {
+		t.Fatalf("expected 'task.updated', got %q", event.Type)
+	}
+}
+
+// --- JSON response tests ---
+
+func TestCreateTask_InvalidJSON(t *testing.T) {
+	srv, _ := testServer(t)
+	ts := httptest.NewServer(srv.Routes())
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/api/v1/tasks", "application/json", bytes.NewReader([]byte("not json")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+}

--- a/internal/server/websocket.go
+++ b/internal/server/websocket.go
@@ -1,0 +1,31 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/gorilla/websocket"
+)
+
+var upgrader = websocket.Upgrader{
+	CheckOrigin: func(r *http.Request) bool { return true },
+}
+
+func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		s.logger.Error("websocket upgrade", "error", err)
+		return
+	}
+
+	s.hub.Register(conn)
+
+	// Read pump: detect client disconnect.
+	go func() {
+		defer s.hub.Unregister(conn)
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}()
+}

--- a/internal/store/tasks.go
+++ b/internal/store/tasks.go
@@ -171,6 +171,26 @@ func (s *Store) CreateTaskLog(ctx context.Context, tl *TaskLog) error {
 	return nil
 }
 
+func (s *Store) ListTaskLogsSince(ctx context.Context, taskID string, afterID int) ([]TaskLog, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT
+		id, task_id, step, stream, line, created_at
+	FROM task_logs WHERE task_id = ? AND id > ? ORDER BY id ASC`, taskID, afterID)
+	if err != nil {
+		return nil, fmt.Errorf("list task logs since: %w", err)
+	}
+	defer rows.Close()
+
+	var logs []TaskLog
+	for rows.Next() {
+		tl, err := scanTaskLog(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan task log: %w", err)
+		}
+		logs = append(logs, *tl)
+	}
+	return logs, rows.Err()
+}
+
 func (s *Store) ListTaskLogs(ctx context.Context, taskID string, step string) ([]TaskLog, error) {
 	var rows *sql.Rows
 	var err error

--- a/internal/store/tasks_test.go
+++ b/internal/store/tasks_test.go
@@ -230,6 +230,60 @@ func TestListTaskLogs(t *testing.T) {
 	}
 }
 
+func TestListTaskLogsSince(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	task := &Task{Prompt: "task", RepoURL: "https://github.com/test/repo", SourceType: "manual", SessionID: "s1"}
+	if err := s.CreateTask(ctx, task); err != nil {
+		t.Fatal(err)
+	}
+
+	logs := []TaskLog{
+		{TaskID: task.ID, Step: "plan", Stream: "stdout", Line: "line 1"},
+		{TaskID: task.ID, Step: "plan", Stream: "stdout", Line: "line 2"},
+		{TaskID: task.ID, Step: "plan", Stream: "stdout", Line: "line 3"},
+	}
+	for i := range logs {
+		if err := s.CreateTaskLog(ctx, &logs[i]); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Get logs after the first one
+	since, err := s.ListTaskLogsSince(ctx, task.ID, logs[0].ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(since) != 2 {
+		t.Fatalf("expected 2 logs, got %d", len(since))
+	}
+	if since[0].Line != "line 2" {
+		t.Fatalf("expected 'line 2', got %q", since[0].Line)
+	}
+	if since[1].Line != "line 3" {
+		t.Fatalf("expected 'line 3', got %q", since[1].Line)
+	}
+
+	// Get all logs (afterID=0)
+	all, err := s.ListTaskLogsSince(ctx, task.ID, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("expected 3 logs, got %d", len(all))
+	}
+
+	// Get none (afterID > last)
+	none, err := s.ListTaskLogsSince(ctx, task.ID, logs[2].ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(none) != 0 {
+		t.Fatalf("expected 0 logs, got %d", len(none))
+	}
+}
+
 func TestDeleteTaskWithLogs(t *testing.T) {
 	s := testStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

- Add `internal/server/` package with full REST API: task CRUD (`POST/GET/DELETE /api/v1/tasks`), plan approval (`POST /tasks/{id}/approve`), plan feedback (`POST /tasks/{id}/feedback`), SSE log streaming (`GET /tasks/{id}/logs`), and agents status (`GET /api/v1/agents`)
- Add WebSocket hub (`/api/v1/ws`) for real-time event broadcasting (`task.created`, `task.updated`, `task.deleted`)
- Add `OnEvent` callback to orchestrator `Config` to bridge status transitions to the WebSocket hub
- Add `ListTaskLogsSince` store method for SSE cursor-based polling
- Wire hub, server, and routes into `cmd/main.go`
- New dependency: `github.com/gorilla/websocket`

## Test plan

- [x] 26 new server tests pass (task CRUD, approval, feedback, SSE logs, agents, hub, WebSocket)
- [x] 1 new store test for `ListTaskLogsSince`
- [x] All existing store and coder tests pass
- [x] All orchestrator tests pass (except pre-existing flaky `TestMultipleTasksQueueing` which also fails on main)
- [x] `go build ./...` compiles cleanly
- [ ] Manual: `curl POST /api/v1/tasks`, verify task created
- [ ] Manual: SSE log streaming with `curl -N GET /api/v1/tasks/{id}/logs`
- [ ] Manual: WebSocket events with `websocat ws://localhost:8080/api/v1/ws`

🤖 Generated with [Claude Code](https://claude.com/claude-code)