### PR TITLE
fix: handle opened action in GitHub webhook handler

### DIFF
--- a/internal/server/handlers_github.go
+++ b/internal/server/handlers_github.go
@@ -47,12 +47,16 @@ func (s *Server) handleGitHubWebhook(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleIssuesEvent(r *http.Request, event *gogithub.IssuesEvent) error {
-	if event.GetAction() != "labeled" {
-		return nil
-	}
-
-	label := event.GetLabel()
-	if label == nil || label.GetName() != aiTaskLabel {
+	switch event.GetAction() {
+	case "labeled":
+		if event.GetLabel().GetName() != aiTaskLabel {
+			return nil
+		}
+	case "opened":
+		if !hasLabel(event.GetIssue(), aiTaskLabel) {
+			return nil
+		}
+	default:
 		return nil
 	}
 
@@ -106,4 +110,13 @@ func (s *Server) handleIssuesEvent(r *http.Request, event *gogithub.IssuesEvent)
 	}
 
 	return nil
+}
+
+func hasLabel(issue *gogithub.Issue, name string) bool {
+	for _, l := range issue.Labels {
+		if l.GetName() == name {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/server/handlers_github_test.go
+++ b/internal/server/handlers_github_test.go
@@ -312,3 +312,118 @@ func TestGitHubWebhook_IssuesLabeled_TitleOnly(t *testing.T) {
 		t.Fatalf("expected prompt to be just title, got %q", tasks[0].Prompt)
 	}
 }
+
+func TestGitHubWebhook_IssuesOpened_WithAITaskLabel(t *testing.T) {
+	ghMux := http.NewServeMux()
+	ghMux.HandleFunc("POST /api/v3/repos/testowner/testrepo/issues/10/comments", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(gogithub.IssueComment{ID: gogithub.Ptr(int64(1))})
+	})
+	ghServer := httptest.NewServer(ghMux)
+	defer ghServer.Close()
+
+	srv, s := testServerWithGitHub(t, ghServer.URL)
+	ts := httptest.NewServer(srv.Routes())
+	defer ts.Close()
+
+	event := gogithub.IssuesEvent{
+		Action: gogithub.Ptr("opened"),
+		Issue: &gogithub.Issue{
+			Number: gogithub.Ptr(10),
+			Title:  gogithub.Ptr("Implement feature X"),
+			Body:   gogithub.Ptr("Details about feature X."),
+			Labels: []*gogithub.Label{
+				{Name: gogithub.Ptr("ai-task")},
+				{Name: gogithub.Ptr("enhancement")},
+			},
+		},
+		Repo: &gogithub.Repository{
+			Name:          gogithub.Ptr("testrepo"),
+			CloneURL:      gogithub.Ptr("https://github.com/testowner/testrepo.git"),
+			DefaultBranch: gogithub.Ptr("main"),
+			Owner:         &gogithub.User{Login: gogithub.Ptr("testowner")},
+		},
+	}
+	payload, _ := json.Marshal(event)
+	signature := signPayload(payload, testWebhookSecret)
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/webhooks/github", strings.NewReader(string(payload)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Hub-Signature-256", signature)
+	req.Header.Set("X-GitHub-Event", "issues")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	tasks, err := s.ListTasks(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(tasks))
+	}
+
+	task := tasks[0]
+	if task.SourceType != "github" {
+		t.Fatalf("expected source_type 'github', got %q", task.SourceType)
+	}
+	if task.GithubIssue == nil || *task.GithubIssue != 10 {
+		t.Fatalf("expected github_issue 10, got %v", task.GithubIssue)
+	}
+	if !strings.Contains(task.Prompt, "Implement feature X") {
+		t.Fatalf("expected prompt to contain title, got %q", task.Prompt)
+	}
+}
+
+func TestGitHubWebhook_IssuesOpened_WithoutAITaskLabel(t *testing.T) {
+	ghServer := httptest.NewServer(http.NewServeMux())
+	defer ghServer.Close()
+
+	srv, s := testServerWithGitHub(t, ghServer.URL)
+	ts := httptest.NewServer(srv.Routes())
+	defer ts.Close()
+
+	event := gogithub.IssuesEvent{
+		Action: gogithub.Ptr("opened"),
+		Issue: &gogithub.Issue{
+			Number: gogithub.Ptr(11),
+			Title:  gogithub.Ptr("Regular issue"),
+			Labels: []*gogithub.Label{
+				{Name: gogithub.Ptr("bug")},
+			},
+		},
+		Repo: &gogithub.Repository{
+			Name:  gogithub.Ptr("testrepo"),
+			Owner: &gogithub.User{Login: gogithub.Ptr("testowner")},
+		},
+	}
+	payload, _ := json.Marshal(event)
+	signature := signPayload(payload, testWebhookSecret)
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/webhooks/github", strings.NewReader(string(payload)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Hub-Signature-256", signature)
+	req.Header.Set("X-GitHub-Event", "issues")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	tasks, _ := s.ListTasks(context.Background(), "")
+	if len(tasks) != 0 {
+		t.Fatalf("expected 0 tasks, got %d", len(tasks))
+	}
+}


### PR DESCRIPTION
## Summary
- Issues created with the `ai-task` label already applied were missed because the handler only checked for `action: "labeled"` — it silently ignored `action: "opened"`
- Added a `switch` on the action to handle both `"labeled"` and `"opened"`, with a `hasLabel` helper that checks the issue's label list for the `"opened"` path
- Added two new tests: one for `opened` with `ai-task` label (task created), one without (no task created)

Closes #10

## Test plan
- [x] `go test ./internal/server/ -run TestGitHub -v` — all 8 tests pass (including 2 new)
- [x] `go test ./...` — full suite passes
- [ ] Deploy to k3s, remove `ai-task` from issue #10, re-add — task should be created
- [ ] Create a new issue with `ai-task` at creation time — task should also be created

🤖 Generated with [Claude Code](https://claude.com/claude-code)