### PR TITLE
fix: deduplicate webhook events and correct Coder template parameter

### DIFF
--- a/internal/orchestrator/steps.go
+++ b/internal/orchestrator/steps.go
@@ -66,7 +66,7 @@ func (o *Orchestrator) stepImplement(ctx context.Context, task *store.Task, work
 // startWorkspace starts the assigned workspace, passing the repo URL as a
 // template parameter so the workspace clones it on boot.
 func (o *Orchestrator) startWorkspace(ctx context.Context, task *store.Task, workspace string) error {
-	params := map[string]string{"repo_url": task.RepoURL}
+	params := map[string]string{"git_repo": task.RepoURL}
 	if err := o.executor.StartWorkspace(ctx, workspace, params); err != nil {
 		return fmt.Errorf("start workspace %s: %w", workspace, err)
 	}

--- a/internal/server/handlers_github.go
+++ b/internal/server/handlers_github.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -69,6 +70,17 @@ func (s *Server) handleIssuesEvent(r *http.Request, event *gogithub.IssuesEvent)
 	s.logger.Info("processing ai-task label",
 		"owner", owner, "repo", repoName, "issue", issueNumber)
 
+	// Deduplicate: skip if a non-failed task already exists for this issue.
+	existing, err := s.store.GetTaskByGithubIssue(r.Context(), owner, repoName, issueNumber)
+	if err != nil && !errors.Is(err, store.ErrNotFound) {
+		return fmt.Errorf("checking existing task: %w", err)
+	}
+	if existing != nil {
+		s.logger.Info("task already exists for issue, skipping",
+			"existing_task", existing.ID, "issue", issueNumber)
+		return nil
+	}
+
 	prompt := issue.GetTitle()
 	if body := issue.GetBody(); body != "" {
 		prompt = prompt + "\n\n" + body
@@ -102,7 +114,7 @@ func (s *Server) handleIssuesEvent(r *http.Request, event *gogithub.IssuesEvent)
 			"I'll post updates here as I progress through planning, implementation, and PR creation.",
 		task.ID,
 	)
-	_, _, err := s.githubClient.Issues.CreateComment(r.Context(), owner, repoName, issueNumber,
+	_, _, err = s.githubClient.Issues.CreateComment(r.Context(), owner, repoName, issueNumber,
 		&gogithub.IssueComment{Body: gogithub.Ptr(comment)})
 	if err != nil {
 		s.logger.Error("failed to post acknowledgement comment", "issue", issueNumber, "error", err)

--- a/internal/server/handlers_github_test.go
+++ b/internal/server/handlers_github_test.go
@@ -382,6 +382,103 @@ func TestGitHubWebhook_IssuesOpened_WithAITaskLabel(t *testing.T) {
 	}
 }
 
+func TestGitHubWebhook_DuplicateIssueEvent_Deduplicated(t *testing.T) {
+	commentCount := 0
+	ghMux := http.NewServeMux()
+	ghMux.HandleFunc("POST /api/v3/repos/testowner/testrepo/issues/20/comments", func(w http.ResponseWriter, r *http.Request) {
+		commentCount++
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(gogithub.IssueComment{ID: gogithub.Ptr(int64(1))})
+	})
+	ghServer := httptest.NewServer(ghMux)
+	defer ghServer.Close()
+
+	srv, s := testServerWithGitHub(t, ghServer.URL)
+	ts := httptest.NewServer(srv.Routes())
+	defer ts.Close()
+
+	// First event: "opened" with ai-task label — should create a task.
+	openedEvent := gogithub.IssuesEvent{
+		Action: gogithub.Ptr("opened"),
+		Issue: &gogithub.Issue{
+			Number: gogithub.Ptr(20),
+			Title:  gogithub.Ptr("Dedup test"),
+			Body:   gogithub.Ptr("Testing dedup."),
+			Labels: []*gogithub.Label{{Name: gogithub.Ptr("ai-task")}},
+		},
+		Repo: &gogithub.Repository{
+			Name:          gogithub.Ptr("testrepo"),
+			CloneURL:      gogithub.Ptr("https://github.com/testowner/testrepo.git"),
+			DefaultBranch: gogithub.Ptr("main"),
+			Owner:         &gogithub.User{Login: gogithub.Ptr("testowner")},
+		},
+	}
+	payload, _ := json.Marshal(openedEvent)
+	sig := signPayload(payload, testWebhookSecret)
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/webhooks/github", strings.NewReader(string(payload)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Hub-Signature-256", sig)
+	req.Header.Set("X-GitHub-Event", "issues")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 for opened event, got %d", resp.StatusCode)
+	}
+
+	// Second event: "labeled" for the same issue — should be deduplicated.
+	labeledEvent := gogithub.IssuesEvent{
+		Action: gogithub.Ptr("labeled"),
+		Label:  &gogithub.Label{Name: gogithub.Ptr("ai-task")},
+		Issue: &gogithub.Issue{
+			Number: gogithub.Ptr(20),
+			Title:  gogithub.Ptr("Dedup test"),
+			Body:   gogithub.Ptr("Testing dedup."),
+			Labels: []*gogithub.Label{{Name: gogithub.Ptr("ai-task")}},
+		},
+		Repo: &gogithub.Repository{
+			Name:          gogithub.Ptr("testrepo"),
+			CloneURL:      gogithub.Ptr("https://github.com/testowner/testrepo.git"),
+			DefaultBranch: gogithub.Ptr("main"),
+			Owner:         &gogithub.User{Login: gogithub.Ptr("testowner")},
+		},
+	}
+	payload2, _ := json.Marshal(labeledEvent)
+	sig2 := signPayload(payload2, testWebhookSecret)
+
+	req2, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/webhooks/github", strings.NewReader(string(payload2)))
+	req2.Header.Set("Content-Type", "application/json")
+	req2.Header.Set("X-Hub-Signature-256", sig2)
+	req2.Header.Set("X-GitHub-Event", "issues")
+
+	resp2, err := http.DefaultClient.Do(req2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp2.Body.Close()
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 for labeled event, got %d", resp2.StatusCode)
+	}
+
+	// Verify only one task was created.
+	tasks, err := s.ListTasks(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task (dedup), got %d", len(tasks))
+	}
+
+	// Verify only one comment was posted.
+	if commentCount != 1 {
+		t.Fatalf("expected 1 comment, got %d", commentCount)
+	}
+}
+
 func TestGitHubWebhook_IssuesOpened_WithoutAITaskLabel(t *testing.T) {
 	ghServer := httptest.NewServer(http.NewServeMux())
 	defer ghServer.Close()

--- a/internal/store/tasks.go
+++ b/internal/store/tasks.go
@@ -9,6 +9,27 @@ import (
 	"github.com/google/uuid"
 )
 
+func (s *Store) GetTaskByGithubIssue(ctx context.Context, owner, repo string, issue int) (*Task, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT
+		id, status, prompt, plan, plan_feedback, repo_url, base_branch,
+		source_type, github_owner, github_repo, github_issue, session_id,
+		workspace_id, current_step, plan_comment_id, plan_revision,
+		pr_url, pr_number, run_tests, decisions,
+		created_at, started_at, completed_at, error_message
+	FROM tasks
+	WHERE github_owner = ? AND github_repo = ? AND github_issue = ? AND status != 'failed'
+	LIMIT 1`, owner, repo, issue)
+
+	t, err := scanTask(row)
+	if err == sql.ErrNoRows {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get task by github issue: %w", err)
+	}
+	return t, nil
+}
+
 func (s *Store) CreateTask(ctx context.Context, t *Task) error {
 	t.ID = uuid.New().String()
 	t.CreatedAt = time.Now().UTC()

--- a/internal/store/tasks_test.go
+++ b/internal/store/tasks_test.go
@@ -164,6 +164,60 @@ func TestDeleteTask(t *testing.T) {
 	}
 }
 
+func TestGetTaskByGithubIssue(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	owner := "testowner"
+	repo := "testrepo"
+	issue := 42
+
+	// No task exists yet — should return ErrNotFound.
+	_, err := s.GetTaskByGithubIssue(ctx, owner, repo, issue)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+
+	// Create a queued task for the issue.
+	task := &Task{
+		Prompt:      "implement feature",
+		RepoURL:     "https://github.com/testowner/testrepo.git",
+		SourceType:  "github",
+		GithubOwner: &owner,
+		GithubRepo:  &repo,
+		GithubIssue: &issue,
+		SessionID:   "s1",
+	}
+	if err := s.CreateTask(ctx, task); err != nil {
+		t.Fatal(err)
+	}
+
+	// Should find the task.
+	got, err := s.GetTaskByGithubIssue(ctx, owner, repo, issue)
+	if err != nil {
+		t.Fatal("expected task, got error:", err)
+	}
+	if got.ID != task.ID {
+		t.Fatalf("expected task ID %q, got %q", task.ID, got.ID)
+	}
+
+	// Mark as failed — should no longer match.
+	task.Status = "failed"
+	if err := s.UpdateTask(ctx, task.ID, task); err != nil {
+		t.Fatal(err)
+	}
+	_, err = s.GetTaskByGithubIssue(ctx, owner, repo, issue)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound for failed task, got %v", err)
+	}
+
+	// Different issue number — should not match.
+	_, err = s.GetTaskByGithubIssue(ctx, owner, repo, 99)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound for different issue, got %v", err)
+	}
+}
+
 func TestCreateTaskLog(t *testing.T) {
 	s := testStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary
- **Duplicate comments**: When a GitHub issue is created with the `ai-task` label already applied, GitHub sends both `opened` and `labeled` events. Both were passing the filter and creating duplicate tasks/comments. Added `GetTaskByGithubIssue` store method and a dedup check in the webhook handler to skip if a non-failed task already exists for the issue.
- **Coder parameter mismatch**: The orchestrator was passing `repo_url` as a Coder template parameter, but the agentic template defines the parameter as `git_repo`. Fixed the key name in `startWorkspace`.

## Test plan
- [x] `go test ./...` — all tests pass
- [x] `go vet ./...` — no issues
- [x] New `TestGetTaskByGithubIssue` verifies store query returns matching task and excludes failed tasks
- [x] New `TestGitHubWebhook_DuplicateIssueEvent_Deduplicated` sends `opened` then `labeled` for the same issue and asserts only 1 task and 1 comment

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)