### PR TITLE
fix: strip ANSI from plans, add --permission-mode plan, include stderr in errors

### DIFF
--- a/internal/orchestrator/log_writer.go
+++ b/internal/orchestrator/log_writer.go
@@ -3,10 +3,18 @@ package orchestrator
 import (
 	"bytes"
 	"context"
+	"regexp"
 	"strings"
 
 	"github.com/jcwearn/agent-orchestrator/internal/store"
 )
+
+// ansiRe matches ANSI escape sequences: CSI sequences, OSC sequences, and simple escapes.
+var ansiRe = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]|\x1b\][^\x07]*\x07|\x1b[()][0-9A-Za-z]|\x1b\[[\?]?[0-9;]*[a-zA-Z]`)
+
+func stripANSI(s string) string {
+	return ansiRe.ReplaceAllString(s, "")
+}
 
 // logWriter splits written bytes into lines and persists each line as a TaskLog.
 // It also accumulates all output for later retrieval via String().
@@ -70,7 +78,17 @@ func (w *logWriter) Flush() error {
 	})
 }
 
-// String returns all accumulated output.
+// String returns all accumulated output with ANSI escape sequences stripped.
 func (w *logWriter) String() string {
-	return w.full.String()
+	return stripANSI(w.full.String())
+}
+
+// Tail returns the last n lines of accumulated output (ANSI-stripped).
+func (w *logWriter) Tail(n int) string {
+	s := stripANSI(w.full.String())
+	lines := strings.Split(s, "\n")
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	return strings.Join(lines, "\n")
 }

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -218,6 +219,15 @@ func TestRunTask_PlanSuccess(t *testing.T) {
 	if o.pool.FreeCount() != len(coder.DefaultWorkspaces) {
 		t.Fatal("workspace not released")
 	}
+	// SSH command should contain --permission-mode plan.
+	exec.mu.Lock()
+	defer exec.mu.Unlock()
+	if len(exec.sshCalls) == 0 {
+		t.Fatal("expected at least one SSH call")
+	}
+	if !strings.Contains(exec.sshCalls[0].Command, "--permission-mode plan") {
+		t.Fatalf("expected --permission-mode plan in command, got: %s", exec.sshCalls[0].Command)
+	}
 }
 
 func TestRunTask_PlanFailure(t *testing.T) {
@@ -295,11 +305,21 @@ func TestRunImplement_Success(t *testing.T) {
 	if o.pool.FreeCount() != len(coder.DefaultWorkspaces) {
 		t.Fatal("workspace not released")
 	}
+	// Implement command should NOT contain --permission-mode plan.
+	exec.mu.Lock()
+	defer exec.mu.Unlock()
+	if len(exec.sshCalls) == 0 {
+		t.Fatal("expected at least one SSH call")
+	}
+	if strings.Contains(exec.sshCalls[0].Command, "--permission-mode plan") {
+		t.Fatalf("implement command should not contain --permission-mode plan, got: %s", exec.sshCalls[0].Command)
+	}
 }
 
 func TestRunImplement_Failure(t *testing.T) {
 	exec := newMockExecutor()
 	exec.sshFunc = func(ctx context.Context, workspace, command string, stdout, stderr io.Writer) (*coder.SSHResult, error) {
+		_, _ = fmt.Fprint(stderr, "Error: authentication failed\nfatal: could not push")
 		return nil, errors.New("implement failed")
 	}
 
@@ -318,6 +338,13 @@ func TestRunImplement_Failure(t *testing.T) {
 	updated, _ := s.GetTask(ctx, task.ID)
 	if updated.Status != StatusFailed {
 		t.Fatalf("expected failed, got %s", updated.Status)
+	}
+	// Error message should contain stderr content.
+	if updated.ErrorMessage == nil {
+		t.Fatal("expected error message")
+	}
+	if !strings.Contains(*updated.ErrorMessage, "authentication failed") {
+		t.Fatalf("expected stderr content in error message, got: %s", *updated.ErrorMessage)
 	}
 }
 
@@ -782,5 +809,49 @@ func TestRunImplement_GitHubNotifyComplete(t *testing.T) {
 	defer notifier.mu.Unlock()
 	if len(notifier.completeCalls) != 1 {
 		t.Fatalf("expected 1 complete call, got %d", len(notifier.completeCalls))
+	}
+}
+
+func TestStripANSI(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"empty", "", ""},
+		{"no escapes", "hello world", "hello world"},
+		{"CSI color", "\x1b[31mred\x1b[0m", "red"},
+		{"CSI cursor", "\x1b[?1004l\x1b[?2004l\x1b[?25h", ""},
+		{"OSC sequence", "\x1b]9;4;0;\x07done", "done"},
+		{"mixed", "\x1b[32mok\x1b[0m plain \x1b]0;title\x07 end", "ok plain  end"},
+		{"multiline with escapes", "\x1b[1mline1\x1b[0m\nline2\n\x1b[33mline3\x1b[0m", "line1\nline2\nline3"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripANSI(tt.input)
+			if got != tt.want {
+				t.Errorf("stripANSI(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLogWriter_Tail(t *testing.T) {
+	exec := newMockExecutor()
+	o, s := testOrchestrator(t, exec, nil)
+	ctx := context.Background()
+	task := createTask(t, s, "tail test")
+
+	w := o.newLogWriter(ctx, task.ID, "plan", "stderr")
+	_, _ = w.Write([]byte("line1\nline2\nline3\nline4\nline5"))
+
+	got := w.Tail(3)
+	if got != "line3\nline4\nline5" {
+		t.Fatalf("Tail(3) = %q, want %q", got, "line3\nline4\nline5")
+	}
+
+	all := w.Tail(100)
+	if all != "line1\nline2\nline3\nline4\nline5" {
+		t.Fatalf("Tail(100) = %q, want all lines", all)
 	}
 }

--- a/internal/orchestrator/steps.go
+++ b/internal/orchestrator/steps.go
@@ -18,7 +18,7 @@ func (o *Orchestrator) stepPlan(ctx context.Context, task *store.Task, workspace
 
 	repoDir := "/home/coder/" + repoName(task.RepoURL)
 	cmd := fmt.Sprintf(
-		"cd %s && git checkout %s && claude --session-id %s -p %s --print",
+		"cd %s && git checkout %s && claude --session-id %s --permission-mode plan -p %s --print",
 		shellQuote(repoDir),
 		shellQuote(task.BaseBranch),
 		shellQuote(task.SessionID),
@@ -30,7 +30,7 @@ func (o *Orchestrator) stepPlan(ctx context.Context, task *store.Task, workspace
 	_ = stderr.Flush()
 
 	if err != nil {
-		return fmt.Errorf("plan step: %w", err)
+		return fmt.Errorf("plan step: %w\n\nstderr tail:\n%s", err, stderr.Tail(20))
 	}
 
 	plan := stdout.String()
@@ -58,7 +58,7 @@ func (o *Orchestrator) stepImplement(ctx context.Context, task *store.Task, work
 	_ = stderr.Flush()
 
 	if err != nil {
-		return fmt.Errorf("implement step: %w", err)
+		return fmt.Errorf("implement step: %w\n\nstderr tail:\n%s", err, stderr.Tail(20))
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Fixes three issues discovered in v0.0.5 testing (issue #16):

- **Plan quality**: Added `--permission-mode plan` to the `claude` command in `stepPlan`, restricting Claude to read-only tools so it focuses on analysis rather than executing commands
- **ANSI garbage in GitHub comments**: Added `stripANSI()` regex helper and applied it in `logWriter.String()` to sanitize terminal escape sequences before they reach `task.Plan` and GitHub comments
- **Unhelpful implement errors**: Added `logWriter.Tail(n)` method and included `stderr.Tail(20)` in both `stepPlan` and `stepImplement` error returns, so failure messages posted to GitHub contain actionable diagnostics

## Test plan

- [x] `TestStripANSI` — table-driven tests for CSI, OSC, color codes, mixed content, empty, no escapes
- [x] `TestLogWriter_Tail` — verifies Tail(3) on 5 lines and Tail(100) returns all
- [x] `TestRunTask_PlanSuccess` — asserts SSH command contains `--permission-mode plan`
- [x] `TestRunImplement_Success` — asserts SSH command does NOT contain `--permission-mode plan`
- [x] `TestRunImplement_Failure` — mock writes stderr, asserts error message contains stderr content
- [x] `go test ./...` passes
- [x] `go vet ./...` clean

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)