### PR TITLE
fix: suppress git checkout noise and broaden ANSI stripping

### DIFF
--- a/internal/orchestrator/log_writer.go
+++ b/internal/orchestrator/log_writer.go
@@ -10,7 +10,7 @@ import (
 )
 
 // ansiRe matches ANSI escape sequences: CSI sequences, OSC sequences, and simple escapes.
-var ansiRe = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]|\x1b\][^\x07]*\x07|\x1b[()][0-9A-Za-z]|\x1b\[[\?]?[0-9;]*[a-zA-Z]`)
+var ansiRe = regexp.MustCompile(`\x1b\[[\x20-\x3f]*[\x40-\x7e]|\x1b\][^\x07]*\x07|\x1b[()][0-9A-Za-z]`)
 
 func stripANSI(s string) string {
 	return ansiRe.ReplaceAllString(s, "")

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -228,6 +228,9 @@ func TestRunTask_PlanSuccess(t *testing.T) {
 	if !strings.Contains(exec.sshCalls[0].Command, "--permission-mode plan") {
 		t.Fatalf("expected --permission-mode plan in command, got: %s", exec.sshCalls[0].Command)
 	}
+	if !strings.Contains(exec.sshCalls[0].Command, "> /dev/null 2>&1") {
+		t.Fatalf("expected git checkout redirected to /dev/null, got: %s", exec.sshCalls[0].Command)
+	}
 }
 
 func TestRunTask_PlanFailure(t *testing.T) {
@@ -825,6 +828,7 @@ func TestStripANSI(t *testing.T) {
 		{"OSC sequence", "\x1b]9;4;0;\x07done", "done"},
 		{"mixed", "\x1b[32mok\x1b[0m plain \x1b]0;title\x07 end", "ok plain  end"},
 		{"multiline with escapes", "\x1b[1mline1\x1b[0m\nline2\n\x1b[33mline3\x1b[0m", "line1\nline2\nline3"},
+		{"CSI private param", "\x1b[<u", ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/orchestrator/steps.go
+++ b/internal/orchestrator/steps.go
@@ -18,7 +18,7 @@ func (o *Orchestrator) stepPlan(ctx context.Context, task *store.Task, workspace
 
 	repoDir := "/home/coder/" + repoName(task.RepoURL)
 	cmd := fmt.Sprintf(
-		"cd %s && git checkout %s && claude --session-id %s --permission-mode plan -p %s --print",
+		"cd %s && git checkout %s > /dev/null 2>&1 && claude --session-id %s --permission-mode plan -p %s --print",
 		shellQuote(repoDir),
 		shellQuote(task.BaseBranch),
 		shellQuote(task.SessionID),
@@ -46,7 +46,7 @@ func (o *Orchestrator) stepImplement(ctx context.Context, task *store.Task, work
 
 	repoDir := "/home/coder/" + repoName(task.RepoURL)
 	cmd := fmt.Sprintf(
-		"cd %s && git checkout %s && claude --resume %s -p %s --print",
+		"cd %s && git checkout %s > /dev/null 2>&1 && claude --resume %s -p %s --print",
 		shellQuote(repoDir),
 		shellQuote(task.BaseBranch),
 		shellQuote(task.SessionID),


### PR DESCRIPTION
## Summary
- Redirect `git checkout` stdout/stderr to `/dev/null` in `stepPlan` and `stepImplement` so git status messages (e.g. "Already on 'main'") don't bleed into captured plan output
- Replace the ANSI escape regex with a broader CSI pattern (`\x1b\[[\x20-\x3f]*[\x40-\x7e]`) that handles private parameter characters like `<`, `>`, `=` — fixing sequences like `\x1b[<u` that were passing through unstripped
- Add test case for `\x1b[<u` in `TestStripANSI`
- Add assertion in `TestRunTask_PlanSuccess` that the SSH command redirects git checkout to `/dev/null`

Closes #18

## Test plan
- [x] `go test ./...` — all pass
- [x] `go vet ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)