### PR TITLE
feat: improve plan agent prompt with exploration-first instructions

### DIFF
--- a/internal/orchestrator/steps.go
+++ b/internal/orchestrator/steps.go
@@ -133,8 +133,26 @@ func (o *Orchestrator) recoverActiveTasks(ctx context.Context) error {
 
 func buildPlanPrompt(task *store.Task) string {
 	return fmt.Sprintf(
-		"You are an AI coding agent. Read the following task and produce a detailed implementation plan. "+
-			"Do NOT implement anything yet — only plan.\n\nTask: %s",
+		"You are a coding agent operating in plan-only mode. Your goal is to explore the codebase "+
+			"and produce an implementation plan for the task below.\n\n"+
+			"BEFORE writing the plan, use your tools to thoroughly explore the repository:\n"+
+			"- Use Glob to find relevant files and understand the project structure\n"+
+			"- Use Grep to search for related code, patterns, and existing conventions\n"+
+			"- Use Read to examine key files, interfaces, and functions you will need to modify or extend\n"+
+			"- Use Bash for read-only commands (e.g., git log, ls) to gather additional context\n\n"+
+			"After exploring, output ONLY the implementation plan in markdown. The plan must include:\n\n"+
+			"1. **Objective** -- One-sentence restatement of what will be built or changed\n"+
+			"2. **Key Findings** -- What you discovered during exploration that informs the approach "+
+			"(existing patterns to follow, utilities to reuse, constraints found)\n"+
+			"3. **Phases** -- Ordered implementation phases, each with:\n"+
+			"   - Description of the work\n"+
+			"   - Specific files to create or modify (full paths)\n"+
+			"   - Key functions, interfaces, or types involved\n"+
+			"   - Concrete steps to take\n"+
+			"4. **Verification** -- How to test and validate the changes\n\n"+
+			"Reference specific files and code you found during exploration. "+
+			"Do not implement anything -- only plan.\n\n"+
+			"Task: %s",
 		task.Prompt,
 	)
 }


### PR DESCRIPTION
## Summary
- Replaces the minimal one-sentence `buildPlanPrompt` with a structured prompt that instructs Claude to explore the codebase using Glob, Grep, Read, and Bash **before** writing the plan
- Defines a 4-section output format (Objective, Key Findings, Phases, Verification) requiring concrete file paths and code references
- This mirrors the behavior that makes Claude Code's interactive plan mode produce high-quality plans — the agent now explores first instead of generating generic advice

## Test plan
- [x] `go test ./internal/orchestrator/...` passes (existing tests check for `--permission-mode plan` in SSH args, not prompt content)
- [ ] Manual E2E: create a task targeting a real repo and compare plan output quality — plans should now contain actual file paths, function names, and concrete steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)