### PR TITLE
fix: prevent agent from planning for wrong repo

### DIFF
--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -815,6 +815,38 @@ func TestRunImplement_GitHubNotifyComplete(t *testing.T) {
 	}
 }
 
+func TestBuildPlanPrompt_IncludesRepoName(t *testing.T) {
+	task := &store.Task{
+		Prompt:  "Add a README",
+		RepoURL: "https://github.com/jcwearn/agent-orchestrator",
+	}
+	prompt := buildPlanPrompt(task)
+
+	if !strings.Contains(prompt, "agent-orchestrator") {
+		t.Fatalf("expected plan prompt to contain repo name, got: %s", prompt)
+	}
+	if !strings.Contains(prompt, "Add a README") {
+		t.Fatalf("expected plan prompt to contain task prompt, got: %s", prompt)
+	}
+}
+
+func TestRepoName(t *testing.T) {
+	tests := []struct {
+		url  string
+		want string
+	}{
+		{"https://github.com/user/repo.git", "repo"},
+		{"https://github.com/user/repo", "repo"},
+		{"https://github.com/jcwearn/agent-orchestrator", "agent-orchestrator"},
+	}
+	for _, tt := range tests {
+		got := repoName(tt.url)
+		if got != tt.want {
+			t.Errorf("repoName(%q) = %q, want %q", tt.url, got, tt.want)
+		}
+	}
+}
+
 func TestStripANSI(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/internal/orchestrator/steps.go
+++ b/internal/orchestrator/steps.go
@@ -133,8 +133,8 @@ func (o *Orchestrator) recoverActiveTasks(ctx context.Context) error {
 
 func buildPlanPrompt(task *store.Task) string {
 	return fmt.Sprintf(
-		"You are a coding agent operating in plan-only mode. Your goal is to explore the codebase "+
-			"and produce an implementation plan for the task below.\n\n"+
+		"You are a coding agent operating in plan-only mode. You are working in the %s repository. "+
+			"Your goal is to explore the codebase and produce an implementation plan for the task below.\n\n"+
 			"BEFORE writing the plan, use your tools to thoroughly explore the repository:\n"+
 			"- Use Glob to find relevant files and understand the project structure\n"+
 			"- Use Grep to search for related code, patterns, and existing conventions\n"+
@@ -153,6 +153,7 @@ func buildPlanPrompt(task *store.Task) string {
 			"Reference specific files and code you found during exploration. "+
 			"Do not implement anything -- only plan.\n\n"+
 			"Task: %s",
+		repoName(task.RepoURL),
 		task.Prompt,
 	)
 }

--- a/internal/server/handlers_github.go
+++ b/internal/server/handlers_github.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	gogithub "github.com/google/go-github/v83/github"
 	"github.com/google/uuid"
@@ -93,7 +94,7 @@ func (s *Server) handleIssuesEvent(r *http.Request, event *gogithub.IssuesEvent)
 
 	task := &store.Task{
 		Prompt:      prompt,
-		RepoURL:     repo.GetCloneURL(),
+		RepoURL:     strings.TrimSuffix(repo.GetCloneURL(), ".git"),
 		BaseBranch:  baseBranch,
 		SourceType:  "github",
 		GithubOwner: &owner,

--- a/internal/server/handlers_github_test.go
+++ b/internal/server/handlers_github_test.go
@@ -168,8 +168,8 @@ func TestGitHubWebhook_IssuesLabeled_CreatesTask(t *testing.T) {
 	if !strings.Contains(task.Prompt, "Redis caching") {
 		t.Fatalf("expected prompt to contain body, got %q", task.Prompt)
 	}
-	if task.RepoURL != "https://github.com/testowner/testrepo.git" {
-		t.Fatalf("expected repo_url, got %q", task.RepoURL)
+	if task.RepoURL != "https://github.com/testowner/testrepo" {
+		t.Fatalf("expected repo_url without .git suffix, got %q", task.RepoURL)
 	}
 	if task.BaseBranch != "main" {
 		t.Fatalf("expected base_branch 'main', got %q", task.BaseBranch)


### PR DESCRIPTION
## Summary
Fixes #20 — agent planned a README for k3s-cluster instead of agent-orchestrator.

- Strip `.git` suffix from GitHub clone URLs in the webhook handler so they match Coder template option values
- Add repo name to the plan prompt so Claude knows which repository it's working in, as a safety net
- Add tests for URL normalization and prompt repo context

## Test plan
- [x] Existing tests updated and passing
- [x] New `TestBuildPlanPrompt_IncludesRepoName` verifies repo name appears in prompt
- [x] New `TestRepoName` covers both `.git` and non-`.git` URL formats
- [ ] Manual: create issue on agent-orchestrator with `ai-task` label, confirm plan references agent-orchestrator

🤖 Generated with [Claude Code](https://claude.com/claude-code)