### PR TITLE
fix: prevent empty plan output from Claude CLI PTY allocation

### DIFF
--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -231,6 +231,9 @@ func TestRunTask_PlanSuccess(t *testing.T) {
 	if !strings.Contains(exec.sshCalls[0].Command, "> /dev/null 2>&1") {
 		t.Fatalf("expected git checkout redirected to /dev/null, got: %s", exec.sshCalls[0].Command)
 	}
+	if !strings.Contains(exec.sshCalls[0].Command, "TERM=dumb claude") {
+		t.Fatalf("expected TERM=dumb before claude command, got: %s", exec.sshCalls[0].Command)
+	}
 }
 
 func TestRunTask_PlanFailure(t *testing.T) {
@@ -869,6 +872,33 @@ func TestStripANSI(t *testing.T) {
 				t.Errorf("stripANSI(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestStepPlan_EmptyOutput(t *testing.T) {
+	exec := newMockExecutor()
+	exec.sshFunc = func(ctx context.Context, workspace, command string, stdout, stderr io.Writer) (*coder.SSHResult, error) {
+		// Simulate PTY junk: SSH succeeds but stdout is empty/whitespace.
+		_, _ = fmt.Fprint(stdout, "   \n\n  ")
+		_, _ = fmt.Fprint(stderr, "some debug output")
+		return &coder.SSHResult{ExitCode: 0}, nil
+	}
+
+	o, s := testOrchestrator(t, exec, nil)
+	ctx := context.Background()
+	task := createTask(t, s, "empty plan")
+
+	ws, _ := o.pool.Acquire(task.ID)
+	task.Status = StatusPlanning
+	_ = s.UpdateTask(ctx, task.ID, task)
+	o.runTask(ctx, task, ws)
+
+	updated, _ := s.GetTask(ctx, task.ID)
+	if updated.Status != StatusFailed {
+		t.Fatalf("expected failed for empty plan, got %s", updated.Status)
+	}
+	if updated.ErrorMessage == nil || !strings.Contains(*updated.ErrorMessage, "empty output") {
+		t.Fatalf("expected error about empty output, got: %v", updated.ErrorMessage)
 	}
 }
 

--- a/internal/orchestrator/steps.go
+++ b/internal/orchestrator/steps.go
@@ -18,7 +18,7 @@ func (o *Orchestrator) stepPlan(ctx context.Context, task *store.Task, workspace
 
 	repoDir := "/home/coder/" + repoName(task.RepoURL)
 	cmd := fmt.Sprintf(
-		"cd %s && git checkout %s > /dev/null 2>&1 && claude --session-id %s --permission-mode plan -p %s --print",
+		"cd %s && git checkout %s > /dev/null 2>&1 && TERM=dumb claude --session-id %s --permission-mode plan -p %s --print",
 		shellQuote(repoDir),
 		shellQuote(task.BaseBranch),
 		shellQuote(task.SessionID),
@@ -29,11 +29,19 @@ func (o *Orchestrator) stepPlan(ctx context.Context, task *store.Task, workspace
 	_ = stdout.Flush()
 	_ = stderr.Flush()
 
+	o.logger.Info("plan step SSH completed",
+		"task_id", task.ID,
+		"stdout_len", len(stdout.String()),
+		"stderr_len", len(stderr.String()))
+
 	if err != nil {
 		return fmt.Errorf("plan step: %w\n\nstderr tail:\n%s", err, stderr.Tail(20))
 	}
 
 	plan := stdout.String()
+	if strings.TrimSpace(plan) == "" {
+		return fmt.Errorf("plan step produced empty output\n\nstderr tail:\n%s\n\nstdout tail:\n%s", stderr.Tail(20), stdout.Tail(20))
+	}
 	task.Plan = &plan
 	return nil
 }
@@ -46,7 +54,7 @@ func (o *Orchestrator) stepImplement(ctx context.Context, task *store.Task, work
 
 	repoDir := "/home/coder/" + repoName(task.RepoURL)
 	cmd := fmt.Sprintf(
-		"cd %s && git checkout %s > /dev/null 2>&1 && claude --resume %s -p %s --print",
+		"cd %s && git checkout %s > /dev/null 2>&1 && TERM=dumb claude --resume %s -p %s --print",
 		shellQuote(repoDir),
 		shellQuote(task.BaseBranch),
 		shellQuote(task.SessionID),


### PR DESCRIPTION
## Summary
- Set `TERM=dumb` before `claude` invocations in `stepPlan()` and `stepImplement()` to prevent TUI initialization when `coder ssh` allocates a PTY
- Detect empty plan output and fail the task with diagnostic context (stderr/stdout tails) instead of silently posting empty content to GitHub
- Add observability logging for stdout/stderr content lengths after SSH completes

Closes #23

## Test plan
- [x] `TestRunTask_PlanSuccess` updated to verify `TERM=dumb` is in the SSH command
- [x] New `TestStepPlan_EmptyOutput` verifies empty stdout fails the task with descriptive error
- [x] `go test ./internal/...` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)