### PR TITLE
fix: add --always-prompt to coder start for parameter overrides

### DIFF
--- a/internal/coder/executor.go
+++ b/internal/coder/executor.go
@@ -66,7 +66,7 @@ func (e *Executor) SSH(ctx context.Context, workspace, command string, stdout, s
 // StartWorkspace starts a Coder workspace via `coder start --yes`.
 // Template parameters (e.g. repo_url) are passed as --parameter key=value flags.
 func (e *Executor) StartWorkspace(ctx context.Context, workspace string, params map[string]string) error {
-	args := []string{"start", workspace, "--yes"}
+	args := []string{"start", workspace, "--yes", "--always-prompt"}
 	for k, v := range params {
 		args = append(args, "--parameter", k+"="+v)
 	}


### PR DESCRIPTION
## Summary
- Adds `--always-prompt` flag to `coder start` command in `StartWorkspace`, ensuring `--parameter` values override the workspace's previous build parameters instead of being silently ignored
- Fixes the root cause of issue #27 where the workspace retained `git_repo` from a prior task

## Context
Without `--always-prompt`, Coder pulls parameter values from the previous build, ignoring `--parameter` flags. This caused workspaces to clone the wrong repository (e.g., `k3s-cluster` instead of `agent-orchestrator`).

Closes #27

## Test plan
- [x] `go test ./...` — all tests pass
- [ ] Manual: create a test issue with `ai-task` label and verify the workspace clones the correct repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)