### PR TITLE
fix: pass all mutable template params with --always-prompt

### DIFF
--- a/internal/orchestrator/steps.go
+++ b/internal/orchestrator/steps.go
@@ -95,7 +95,12 @@ func (o *Orchestrator) stepImplement(ctx context.Context, task *store.Task, work
 // startWorkspace starts the assigned workspace, passing the repo URL as a
 // template parameter so the workspace clones it on boot.
 func (o *Orchestrator) startWorkspace(ctx context.Context, task *store.Task, workspace string) error {
-	params := map[string]string{"git_repo": task.RepoURL}
+	params := map[string]string{
+		"git_repo":     task.RepoURL,
+		"cpu":          "4",
+		"memory":       "8",
+		"dotfiles_uri": "https://github.com/jcwearn/dotfiles-coder",
+	}
 	if err := o.executor.StartWorkspace(ctx, workspace, params); err != nil {
 		return fmt.Errorf("start workspace %s: %w", workspace, err)
 	}


### PR DESCRIPTION
## Summary

- `--always-prompt` resets ALL workspace parameters, causing interactive prompts for `cpu`, `memory`, and `dotfiles_uri` that fail in non-interactive mode
- Pass all four mutable template parameters (`git_repo`, `cpu`, `memory`, `dotfiles_uri`) with their default values to prevent prompting

## Context

PR #28 added `--always-prompt` to fix parameter overrides (#27). However, it caused `coder start` to prompt for every mutable parameter — not just `git_repo` — which fails in non-interactive mode with: `error creating cancelreader: add reader to epoll interest list`.

Manually verified that passing all four parameters with `--always-prompt` works correctly.

## Test plan

- [x] `go test ./...` passes
- [x] Manual verification: `coder start` with all four `--parameter` flags succeeds without interactive prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)