### PR TITLE
fix: add retry logic to verifyRepoDir for NFS timing races

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -21,14 +21,15 @@ type Notifier interface {
 
 // Config holds orchestrator settings.
 type Config struct {
-	TickInterval time.Duration
-	OnEvent      func(taskID, eventType string)
-	Notifier     Notifier
+	TickInterval   time.Duration
+	VerifyRetryDelay time.Duration // delay between verifyRepoDir retries (default 5s)
+	OnEvent        func(taskID, eventType string)
+	Notifier       Notifier
 }
 
 // DefaultConfig returns sensible defaults: 5-second tick interval.
 func DefaultConfig() Config {
-	return Config{TickInterval: 5 * time.Second}
+	return Config{TickInterval: 5 * time.Second, VerifyRetryDelay: 5 * time.Second}
 }
 
 // Orchestrator polls for queued tasks, assigns workspaces, and drives them

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -95,7 +95,7 @@ func testOrchestrator(t *testing.T, exec *mockExecutor, pool *coder.Pool) (*Orch
 	if pool == nil {
 		pool = coder.NewPool(coder.DefaultWorkspaces)
 	}
-	o := New(s, exec, pool, slog.Default(), Config{TickInterval: 50 * time.Millisecond})
+	o := New(s, exec, pool, slog.Default(), Config{TickInterval: 50 * time.Millisecond, VerifyRetryDelay: 10 * time.Millisecond})
 	return o, s
 }
 
@@ -951,11 +951,50 @@ func TestStepPlan_VerifyRepoDirFailure(t *testing.T) {
 	if updated.ErrorMessage == nil || !strings.Contains(*updated.ErrorMessage, "repo directory") {
 		t.Fatalf("expected error about repo directory, got: %v", updated.ErrorMessage)
 	}
-	// Only the verify SSH call should have been made (no Claude call).
+	if !strings.Contains(*updated.ErrorMessage, "not found after 5 attempts") {
+		t.Fatalf("expected retry exhaustion message, got: %v", updated.ErrorMessage)
+	}
+	// 5 verify retries + 1 diagnostic call, no Claude call.
 	exec.mu.Lock()
 	defer exec.mu.Unlock()
-	if len(exec.sshCalls) != 1 {
-		t.Fatalf("expected 1 SSH call (verify only), got %d", len(exec.sshCalls))
+	if len(exec.sshCalls) != 6 {
+		t.Fatalf("expected 6 SSH calls (5 verify retries + 1 diagnostic), got %d", len(exec.sshCalls))
+	}
+}
+
+func TestStepPlan_VerifyRepoDirRetryThenSuccess(t *testing.T) {
+	exec := newMockExecutor()
+	var verifyAttempts int
+	exec.sshFunc = func(ctx context.Context, workspace, command string, stdout, stderr io.Writer) (*coder.SSHResult, error) {
+		if strings.Contains(command, "test -d") {
+			verifyAttempts++
+			if verifyAttempts < 3 {
+				return &coder.SSHResult{ExitCode: 1}, fmt.Errorf("command exited with code 1: exit status 1")
+			}
+			return &coder.SSHResult{ExitCode: 0}, nil
+		}
+		_, _ = fmt.Fprint(stdout, "the plan")
+		return &coder.SSHResult{ExitCode: 0}, nil
+	}
+
+	o, s := testOrchestrator(t, exec, nil)
+	ctx := context.Background()
+	task := createTask(t, s, "retry repo")
+
+	ws, _ := o.pool.Acquire(task.ID)
+	task.Status = StatusPlanning
+	_ = s.UpdateTask(ctx, task.ID, task)
+	o.runTask(ctx, task, ws)
+
+	updated, _ := s.GetTask(ctx, task.ID)
+	if updated.Status != StatusAwaitingApproval {
+		t.Fatalf("expected awaiting_approval, got %s", updated.Status)
+	}
+	// 3 verify attempts + 1 plan call.
+	exec.mu.Lock()
+	defer exec.mu.Unlock()
+	if len(exec.sshCalls) != 4 {
+		t.Fatalf("expected 4 SSH calls (3 verify attempts + 1 plan), got %d", len(exec.sshCalls))
 	}
 }
 

--- a/internal/orchestrator/steps.go
+++ b/internal/orchestrator/steps.go
@@ -14,14 +14,51 @@ import (
 // verifyRepoDir checks that the expected repo directory exists in the workspace.
 // This catches cases where the Coder parameter didn't apply (stale workspace,
 // parameter mismatch, clone failure).
+//
+// Retries up to 5 times with 5s delays to handle NFS attribute caching and
+// workspace startup timing races (wait_for_rollout=false + start_blocks_login).
 func (o *Orchestrator) verifyRepoDir(ctx context.Context, workspace, repoDir string) error {
-	var stdout, stderr bytes.Buffer
-	cmd := fmt.Sprintf("test -d %s/.git", shellQuote(repoDir))
-	_, err := o.executor.SSH(ctx, workspace, cmd, &stdout, &stderr)
-	if err != nil {
-		return fmt.Errorf("repo directory %s not found in workspace: %w", repoDir, err)
+	const maxAttempts = 5
+	retryDelay := o.config.VerifyRetryDelay
+	if retryDelay == 0 {
+		retryDelay = 5 * time.Second
 	}
-	return nil
+
+	cmd := fmt.Sprintf("test -d %s/.git", shellQuote(repoDir))
+
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		var stdout, stderr bytes.Buffer
+		_, err := o.executor.SSH(ctx, workspace, cmd, &stdout, &stderr)
+		if err == nil {
+			if attempt > 1 {
+				o.logger.Info("verifyRepoDir succeeded after retry",
+					"workspace", workspace, "repo_dir", repoDir, "attempt", attempt)
+			}
+			return nil
+		}
+		lastErr = err
+		o.logger.Warn("verifyRepoDir attempt failed",
+			"workspace", workspace, "repo_dir", repoDir,
+			"attempt", attempt, "max_attempts", maxAttempts, "error", err)
+
+		if attempt < maxAttempts {
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("repo directory %s verification cancelled: %w", repoDir, ctx.Err())
+			case <-time.After(retryDelay):
+			}
+		}
+	}
+
+	// Collect diagnostics on final failure.
+	var diagOut, diagErr bytes.Buffer
+	diagCmd := fmt.Sprintf("ls -la %s/ 2>&1 || echo 'parent dir not found'; ls -la %s/.git 2>&1 || echo '.git not found'",
+		shellQuote(path.Dir(repoDir+"/x")), shellQuote(repoDir))
+	_, _ = o.executor.SSH(ctx, workspace, diagCmd, &diagOut, &diagErr)
+
+	return fmt.Errorf("repo directory %s not found after %d attempts: %w\n\ndiagnostics:\n%s",
+		repoDir, maxAttempts, lastErr, diagOut.String())
 }
 
 // stepPlan invokes Claude CLI to produce a plan. The repo is already cloned


### PR DESCRIPTION
## Summary
- Adds retry logic (5 attempts, 5s delay) to `verifyRepoDir()` to handle NFS attribute caching and `wait_for_rollout=false` timing races after workspace startup
- Logs warnings on each failed attempt and an info message when succeeding after retry
- Collects diagnostic `ls` output on final failure for debugging
- Makes retry delay configurable via `Config.VerifyRetryDelay` (tests use 10ms)

## Test plan
- [x] Existing tests updated and passing
- [x] New test for retry-then-succeed case added
- [ ] Deploy v0.0.14 and verify tasks progress past verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)