### PR TITLE
fix: wait for Coder agent ready before verifying repo directory

### DIFF
--- a/internal/coder/executor.go
+++ b/internal/coder/executor.go
@@ -114,8 +114,9 @@ func (e *Executor) ListWorkspaces(ctx context.Context) ([]WorkspaceInfo, error) 
 	infos := make([]WorkspaceInfo, len(raw))
 	for i, w := range raw {
 		infos[i] = WorkspaceInfo{
-			Name:   w.Name,
-			Status: parseWorkspaceStatus(w.LatestBuild.Status),
+			Name:           w.Name,
+			Status:         parseWorkspaceStatus(w.LatestBuild.Status),
+			AgentLifecycle: firstAgentLifecycle(w.LatestBuild.Resources),
 		}
 	}
 	return infos, nil
@@ -128,7 +129,16 @@ type coderWorkspace struct {
 }
 
 type coderBuild struct {
-	Status string `json:"status"`
+	Status    string          `json:"status"`
+	Resources []coderResource `json:"resources"`
+}
+
+type coderResource struct {
+	Agents []coderAgent `json:"agents"`
+}
+
+type coderAgent struct {
+	LifecycleState string `json:"lifecycle_state"`
 }
 
 // WorkspaceStatus represents the state of a Coder workspace.
@@ -150,8 +160,20 @@ const (
 
 // WorkspaceInfo holds the name and current status of a workspace.
 type WorkspaceInfo struct {
-	Name   string
-	Status WorkspaceStatus
+	Name           string
+	Status         WorkspaceStatus
+	AgentLifecycle string // "ready", "starting", "start_error", "start_timeout", etc.
+}
+
+// firstAgentLifecycle returns the lifecycle_state of the first agent found
+// across all resources, or "" if no agents exist.
+func firstAgentLifecycle(resources []coderResource) string {
+	for _, r := range resources {
+		for _, a := range r.Agents {
+			return a.LifecycleState
+		}
+	}
+	return ""
 }
 
 func parseWorkspaceStatus(s string) WorkspaceStatus {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -21,15 +21,22 @@ type Notifier interface {
 
 // Config holds orchestrator settings.
 type Config struct {
-	TickInterval   time.Duration
-	VerifyRetryDelay time.Duration // delay between verifyRepoDir retries (default 5s)
-	OnEvent        func(taskID, eventType string)
-	Notifier       Notifier
+	TickInterval           time.Duration
+	VerifyRetryDelay       time.Duration // delay between verifyRepoDir retries (default 5s)
+	AgentReadyTimeout      time.Duration // max wait for agent lifecycle "ready" (default 2m)
+	AgentReadyPollInterval time.Duration // poll interval for agent readiness (default 5s)
+	OnEvent                func(taskID, eventType string)
+	Notifier               Notifier
 }
 
 // DefaultConfig returns sensible defaults: 5-second tick interval.
 func DefaultConfig() Config {
-	return Config{TickInterval: 5 * time.Second, VerifyRetryDelay: 5 * time.Second}
+	return Config{
+		TickInterval:           5 * time.Second,
+		VerifyRetryDelay:       5 * time.Second,
+		AgentReadyTimeout:      2 * time.Minute,
+		AgentReadyPollInterval: 5 * time.Second,
+	}
 }
 
 // Orchestrator polls for queued tasks, assigns workspaces, and drives them

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -23,6 +23,7 @@ type mockExecutor struct {
 	sshFunc     func(ctx context.Context, workspace, command string, stdout, stderr io.Writer) (*coder.SSHResult, error)
 	startFunc   func(ctx context.Context, workspace string, params map[string]string) error
 	stopFunc    func(ctx context.Context, workspace string) error
+	listFunc    func(ctx context.Context) ([]coder.WorkspaceInfo, error)
 	sshCalls    []sshCall
 	startCalls  []string
 	stopCalls   []string
@@ -43,6 +44,13 @@ func newMockExecutor() *mockExecutor {
 		},
 		startFunc: func(ctx context.Context, workspace string, params map[string]string) error { return nil },
 		stopFunc:  func(ctx context.Context, workspace string) error { return nil },
+		listFunc: func(ctx context.Context) ([]coder.WorkspaceInfo, error) {
+			var infos []coder.WorkspaceInfo
+			for _, name := range coder.DefaultWorkspaces {
+				infos = append(infos, coder.WorkspaceInfo{Name: name, Status: coder.WorkspaceStatusRunning, AgentLifecycle: "ready"})
+			}
+			return infos, nil
+		},
 	}
 }
 
@@ -68,7 +76,7 @@ func (m *mockExecutor) StopWorkspace(ctx context.Context, workspace string) erro
 }
 
 func (m *mockExecutor) ListWorkspaces(ctx context.Context) ([]coder.WorkspaceInfo, error) {
-	return nil, nil
+	return m.listFunc(ctx)
 }
 
 // --- test helpers ---
@@ -95,7 +103,12 @@ func testOrchestrator(t *testing.T, exec *mockExecutor, pool *coder.Pool) (*Orch
 	if pool == nil {
 		pool = coder.NewPool(coder.DefaultWorkspaces)
 	}
-	o := New(s, exec, pool, slog.Default(), Config{TickInterval: 50 * time.Millisecond, VerifyRetryDelay: 10 * time.Millisecond})
+	o := New(s, exec, pool, slog.Default(), Config{
+		TickInterval:           50 * time.Millisecond,
+		VerifyRetryDelay:       10 * time.Millisecond,
+		AgentReadyTimeout:      2 * time.Second,
+		AgentReadyPollInterval: 10 * time.Millisecond,
+	})
 	return o, s
 }
 
@@ -539,6 +552,12 @@ func TestMultipleTasksQueueing(t *testing.T) {
 			_, _ = fmt.Fprint(stdout, "plan")
 		}
 		return &coder.SSHResult{ExitCode: 0}, nil
+	}
+	exec.listFunc = func(ctx context.Context) ([]coder.WorkspaceInfo, error) {
+		return []coder.WorkspaceInfo{
+			{Name: "ws-1", Status: coder.WorkspaceStatusRunning, AgentLifecycle: "ready"},
+			{Name: "ws-2", Status: coder.WorkspaceStatusRunning, AgentLifecycle: "ready"},
+		}, nil
 	}
 
 	pool := coder.NewPool([]string{"ws-1", "ws-2"})
@@ -1051,5 +1070,82 @@ func TestLogWriter_Tail(t *testing.T) {
 	all := w.Tail(100)
 	if all != "line1\nline2\nline3\nline4\nline5" {
 		t.Fatalf("Tail(100) = %q, want all lines", all)
+	}
+}
+
+func TestWaitForAgentReady_ImmediateReady(t *testing.T) {
+	exec := newMockExecutor()
+	exec.listFunc = func(ctx context.Context) ([]coder.WorkspaceInfo, error) {
+		return []coder.WorkspaceInfo{
+			{Name: "ws-1", Status: coder.WorkspaceStatusRunning, AgentLifecycle: "ready"},
+		}, nil
+	}
+
+	o, _ := testOrchestrator(t, exec, nil)
+	if err := o.waitForAgentReady(context.Background(), "ws-1"); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestWaitForAgentReady_TransitionToReady(t *testing.T) {
+	exec := newMockExecutor()
+	var calls int
+	exec.listFunc = func(ctx context.Context) ([]coder.WorkspaceInfo, error) {
+		calls++
+		state := "starting"
+		if calls >= 3 {
+			state = "ready"
+		}
+		return []coder.WorkspaceInfo{
+			{Name: "ws-1", Status: coder.WorkspaceStatusRunning, AgentLifecycle: state},
+		}, nil
+	}
+
+	o, _ := testOrchestrator(t, exec, nil)
+	if err := o.waitForAgentReady(context.Background(), "ws-1"); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if calls < 3 {
+		t.Fatalf("expected at least 3 list calls, got %d", calls)
+	}
+}
+
+func TestWaitForAgentReady_StartError(t *testing.T) {
+	exec := newMockExecutor()
+	exec.listFunc = func(ctx context.Context) ([]coder.WorkspaceInfo, error) {
+		return []coder.WorkspaceInfo{
+			{Name: "ws-1", Status: coder.WorkspaceStatusRunning, AgentLifecycle: "start_error"},
+		}, nil
+	}
+
+	o, _ := testOrchestrator(t, exec, nil)
+	err := o.waitForAgentReady(context.Background(), "ws-1")
+	if err == nil {
+		t.Fatal("expected error for start_error lifecycle")
+	}
+	if !strings.Contains(err.Error(), "start_error") {
+		t.Fatalf("expected start_error in message, got: %v", err)
+	}
+}
+
+func TestWaitForAgentReady_Timeout(t *testing.T) {
+	exec := newMockExecutor()
+	exec.listFunc = func(ctx context.Context) ([]coder.WorkspaceInfo, error) {
+		return []coder.WorkspaceInfo{
+			{Name: "ws-1", Status: coder.WorkspaceStatusRunning, AgentLifecycle: "starting"},
+		}, nil
+	}
+
+	o, _ := testOrchestrator(t, exec, nil)
+	// Override with a very short timeout for this test.
+	o.config.AgentReadyTimeout = 100 * time.Millisecond
+	o.config.AgentReadyPollInterval = 20 * time.Millisecond
+
+	err := o.waitForAgentReady(context.Background(), "ws-1")
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("expected timeout message, got: %v", err)
 	}
 }

--- a/internal/orchestrator/steps.go
+++ b/internal/orchestrator/steps.go
@@ -130,7 +130,8 @@ func (o *Orchestrator) stepImplement(ctx context.Context, task *store.Task, work
 }
 
 // startWorkspace starts the assigned workspace, passing the repo URL as a
-// template parameter so the workspace clones it on boot.
+// template parameter so the workspace clones it on boot. After the build
+// completes, it waits for the agent to reach "ready" before returning.
 func (o *Orchestrator) startWorkspace(ctx context.Context, task *store.Task, workspace string) error {
 	params := map[string]string{
 		"git_repo":     task.RepoURL,
@@ -141,9 +142,61 @@ func (o *Orchestrator) startWorkspace(ctx context.Context, task *store.Task, wor
 	if err := o.executor.StartWorkspace(ctx, workspace, params); err != nil {
 		return fmt.Errorf("start workspace %s: %w", workspace, err)
 	}
+	if err := o.waitForAgentReady(ctx, workspace); err != nil {
+		return fmt.Errorf("wait for workspace %s agent: %w", workspace, err)
+	}
 	ws := workspace
 	task.WorkspaceID = &ws
 	return nil
+}
+
+// waitForAgentReady polls ListWorkspaces until the named workspace's agent
+// reports lifecycle_state "ready". It returns an error immediately on
+// "start_error" or "start_timeout", and returns a timeout error if the agent
+// doesn't become ready within AgentReadyTimeout.
+func (o *Orchestrator) waitForAgentReady(ctx context.Context, workspace string) error {
+	timeout := o.config.AgentReadyTimeout
+	if timeout == 0 {
+		timeout = 2 * time.Minute
+	}
+	poll := o.config.AgentReadyPollInterval
+	if poll == 0 {
+		poll = 5 * time.Second
+	}
+
+	deadline := time.After(timeout)
+	for {
+		workspaces, err := o.executor.ListWorkspaces(ctx)
+		if err != nil {
+			return fmt.Errorf("list workspaces: %w", err)
+		}
+
+		for _, ws := range workspaces {
+			if ws.Name != workspace {
+				continue
+			}
+			switch ws.AgentLifecycle {
+			case "ready":
+				o.logger.Info("agent ready", "workspace", workspace)
+				return nil
+			case "start_error":
+				return fmt.Errorf("agent startup failed (lifecycle_state: start_error)")
+			case "start_timeout":
+				return fmt.Errorf("agent startup timed out (lifecycle_state: start_timeout)")
+			default:
+				o.logger.Debug("waiting for agent ready",
+					"workspace", workspace, "lifecycle_state", ws.AgentLifecycle)
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("context cancelled waiting for agent ready: %w", ctx.Err())
+		case <-deadline:
+			return fmt.Errorf("timed out waiting for agent ready after %s", timeout)
+		case <-time.After(poll):
+		}
+	}
 }
 
 // stopAndRelease stops the workspace and releases it back to the pool.


### PR DESCRIPTION
## Summary

- After `coder start` returns (build complete), poll the workspace agent's `lifecycle_state` via `coder list --output json` until it reports `"ready"` before proceeding to `verifyRepoDir`
- Immediately fail on `"start_error"` or `"start_timeout"` lifecycle states
- Configurable timeout (default 2min) and poll interval (default 5s) via `AgentReadyTimeout` and `AgentReadyPollInterval` in `Config`

## Context

`coder start` returns when the **build** finishes, not when the **agent** is ready. The agent runs startup scripts (including repo clone with `start_blocks_login = true`) after the build. The previous `verifyRepoDir` retry logic (25s window) was insufficient — now we wait for the agent lifecycle to reach `"ready"`, guaranteeing startup scripts have completed.

## Test plan

- [x] `go test ./...` — all tests pass
- [x] New tests: `waitForAgentReady` immediate ready, transition from starting→ready, start_error, timeout
- [x] Existing tests updated with configurable `listFunc` mock (defaults to agent ready)
- [ ] Deploy and verify: workspace starts → agent reaches ready → verifyRepoDir succeeds on first attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)