### PR TITLE
fix: pass SSH command as single arg to prevent bash -c splitting

### DIFF
--- a/internal/coder/executor.go
+++ b/internal/coder/executor.go
@@ -45,9 +45,12 @@ func NewExecutor(logger *slog.Logger, newCmd CommandCreator) *Executor {
 }
 
 // SSH runs a command inside a Coder workspace via `coder ssh`.
-// stdout and stderr are streamed to the provided writers in real-time.
+// The command string is passed as a single argument after "--" so the remote
+// shell receives it intact. Do NOT split into "bash", "-c", command — coder ssh
+// joins args with spaces before sending to the remote shell, which causes
+// bash -c to receive only the first word as the script.
 func (e *Executor) SSH(ctx context.Context, workspace, command string, stdout, stderr io.Writer) (*SSHResult, error) {
-	cmd := e.newCmd(ctx, "coder", "ssh", workspace, "--", "bash", "-c", command)
+	cmd := e.newCmd(ctx, "coder", "ssh", workspace, "--", command)
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 

--- a/internal/coder/executor_test.go
+++ b/internal/coder/executor_test.go
@@ -201,3 +201,31 @@ func TestListWorkspaces_InvalidJSON(t *testing.T) {
 		t.Fatal("expected parse error")
 	}
 }
+
+func TestSSH_NoExplicitBashShell(t *testing.T) {
+	// Regression: coder ssh joins args after "--" with spaces before sending
+	// to the remote shell. Using "bash", "-c", command as separate args caused
+	// the remote shell to run "bash -c <first-word>" instead of the full command.
+	var capturedArgs []string
+	creator := func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		capturedArgs = append([]string{name}, args...)
+		// Return a no-op command.
+		return exec.CommandContext(ctx, "true")
+	}
+	e := NewExecutor(slog.Default(), creator)
+
+	var stdout, stderr bytes.Buffer
+	_, _ = e.SSH(context.Background(), "ws-1", "test -d /home/coder/repo/.git", &stdout, &stderr)
+
+	// Expected: ["coder", "ssh", "ws-1", "--", "test -d /home/coder/repo/.git"]
+	// The command must be a single arg after "--", not split into "bash", "-c", command.
+	if len(capturedArgs) != 5 {
+		t.Fatalf("expected 5 args, got %d: %v", len(capturedArgs), capturedArgs)
+	}
+	if capturedArgs[3] != "--" {
+		t.Fatalf("expected arg[3] = '--', got %q", capturedArgs[3])
+	}
+	if capturedArgs[4] != "test -d /home/coder/repo/.git" {
+		t.Fatalf("expected arg[4] = full command string, got %q", capturedArgs[4])
+	}
+}


### PR DESCRIPTION
## Summary

- Root cause of [#36](https://github.com/jcwearn/agent-orchestrator/issues/36): `coder ssh` joins args after `--` with spaces before sending to the remote shell. Passing `"bash", "-c", command` as separate Go `exec.CommandContext` args caused the remote shell to receive `bash -c <first-word-only>`, running just the first word (`test`) with no arguments (exit 1) — regardless of whether `.git` actually exists.
- Fix: pass the command string as a single arg after `--` so the remote shell receives it intact
- Added regression test `TestSSH_NoExplicitBashShell` that verifies the command is passed as a single arg

## Reproduction

```bash
# This is what the old code effectively did (FAILS):
coder ssh agent-1 -- bash -c "test -d /home/coder/agent-orchestrator/.git && echo OK || echo FAIL"
# Output: FAIL

# This is what the fix does (WORKS):
coder ssh agent-1 -- "test -d /home/coder/agent-orchestrator/.git && echo OK || echo FAIL"
# Output: OK
```

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] New regression test verifies args structure
- [ ] Deploy and verify with a live CodingTask

Fixes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)