### PR TITLE
fix: prevent task duplication and remove --resume from implement step

### DIFF
--- a/internal/orchestrator/steps.go
+++ b/internal/orchestrator/steps.go
@@ -100,7 +100,7 @@ func (o *Orchestrator) stepPlan(ctx context.Context, task *store.Task, workspace
 	return nil
 }
 
-// stepImplement resumes the Claude session to implement the approved plan.
+// stepImplement invokes Claude CLI to implement the approved plan.
 // The repo is already present from the workspace template.
 func (o *Orchestrator) stepImplement(ctx context.Context, task *store.Task, workspace string) error {
 	stdout := o.newLogWriter(ctx, task.ID, "implement", "stdout")
@@ -112,10 +112,9 @@ func (o *Orchestrator) stepImplement(ctx context.Context, task *store.Task, work
 	}
 
 	cmd := fmt.Sprintf(
-		"cd %s && git checkout %s > /dev/null 2>&1 && TERM=dumb claude --resume %s -p %s --print",
+		"cd %s && git checkout %s > /dev/null 2>&1 && TERM=dumb claude -p %s --print",
 		shellQuote(repoDir),
 		shellQuote(task.BaseBranch),
-		shellQuote(task.SessionID),
 		shellQuote(buildImplementPrompt(task)),
 	)
 

--- a/internal/server/handlers_github.go
+++ b/internal/server/handlers_github.go
@@ -104,6 +104,11 @@ func (s *Server) handleIssuesEvent(r *http.Request, event *gogithub.IssuesEvent)
 	}
 
 	if err := s.store.CreateTask(r.Context(), task); err != nil {
+		if errors.Is(err, store.ErrDuplicateTask) {
+			s.logger.Info("duplicate task prevented by constraint, skipping",
+				"owner", owner, "repo", repoName, "issue", issueNumber)
+			return nil
+		}
 		return fmt.Errorf("creating task: %w", err)
 	}
 

--- a/internal/store/migrations/002_github_issue_unique.sql
+++ b/internal/store/migrations/002_github_issue_unique.sql
@@ -1,0 +1,3 @@
+CREATE UNIQUE INDEX idx_tasks_github_issue_unique
+ON tasks(github_owner, github_repo, github_issue)
+WHERE status != 'failed';

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -10,6 +10,7 @@ import (
 )
 
 var ErrNotFound = errors.New("not found")
+var ErrDuplicateTask = errors.New("duplicate task")
 
 type Store struct {
 	db     *sql.DB

--- a/internal/store/tasks.go
+++ b/internal/store/tasks.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -61,6 +62,9 @@ func (s *Store) CreateTask(ctx context.Context, t *Task) error {
 		t.CreatedAt, t.StartedAt, t.CompletedAt, t.ErrorMessage,
 	)
 	if err != nil {
+		if strings.Contains(err.Error(), "UNIQUE constraint failed") {
+			return ErrDuplicateTask
+		}
 		return fmt.Errorf("insert task: %w", err)
 	}
 	return nil

--- a/internal/store/tasks_test.go
+++ b/internal/store/tasks_test.go
@@ -218,6 +218,61 @@ func TestGetTaskByGithubIssue(t *testing.T) {
 	}
 }
 
+func TestCreateTask_DuplicateGitHubIssue(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	owner := "testowner"
+	repo := "testrepo"
+	issue := 42
+
+	first := &Task{
+		Prompt:      "implement feature",
+		RepoURL:     "https://github.com/testowner/testrepo",
+		SourceType:  "github",
+		GithubOwner: &owner,
+		GithubRepo:  &repo,
+		GithubIssue: &issue,
+		SessionID:   "s1",
+	}
+	if err := s.CreateTask(ctx, first); err != nil {
+		t.Fatal("first create should succeed:", err)
+	}
+
+	// Second create for the same issue should return ErrDuplicateTask.
+	second := &Task{
+		Prompt:      "implement feature (dup)",
+		RepoURL:     "https://github.com/testowner/testrepo",
+		SourceType:  "github",
+		GithubOwner: &owner,
+		GithubRepo:  &repo,
+		GithubIssue: &issue,
+		SessionID:   "s2",
+	}
+	if err := s.CreateTask(ctx, second); !errors.Is(err, ErrDuplicateTask) {
+		t.Fatalf("expected ErrDuplicateTask, got %v", err)
+	}
+
+	// After marking first as failed, a retry should succeed.
+	first.Status = "failed"
+	if err := s.UpdateTask(ctx, first.ID, first); err != nil {
+		t.Fatal("update to failed:", err)
+	}
+
+	third := &Task{
+		Prompt:      "implement feature (retry)",
+		RepoURL:     "https://github.com/testowner/testrepo",
+		SourceType:  "github",
+		GithubOwner: &owner,
+		GithubRepo:  &repo,
+		GithubIssue: &issue,
+		SessionID:   "s3",
+	}
+	if err := s.CreateTask(ctx, third); err != nil {
+		t.Fatal("retry after failure should succeed:", err)
+	}
+}
+
 func TestCreateTaskLog(t *testing.T) {
 	s := testStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary
- Add partial unique index on `(github_owner, github_repo, github_issue) WHERE status != 'failed'` to prevent TOCTOU race between concurrent "opened" and "labeled" webhook events creating duplicate tasks
- Handle `ErrDuplicateTask` gracefully in the webhook handler (log + return 200)
- Remove `--resume` from the implement step — the workspace is rebuilt between plan and implement, destroying the Claude session; the implement prompt already includes the full approved plan

## Test plan
- [x] `go test ./...` passes (all existing + new test)
- [ ] Deploy and create a GitHub issue with `ai-task` label pre-applied — verify only one task despite both "opened" and "labeled" events
- [ ] Approve plan via thumbs-up — verify implement step runs without `--resume` failure

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)