### PR TITLE
feat: post implementation-started comment and capture PR URL

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -191,6 +191,10 @@ func (a *notifierAdapter) CheckApproval(ctx context.Context, owner, repo string,
 	return false, result.Feedback, nil
 }
 
+func (a *notifierAdapter) NotifyImplementationStarted(ctx context.Context, owner, repo string, issue int) error {
+	return a.notifier.NotifyImplementationStarted(ctx, owner, repo, issue)
+}
+
 func (a *notifierAdapter) NotifyComplete(ctx context.Context, owner, repo string, issue int, prURL string) error {
 	return a.notifier.NotifyComplete(ctx, owner, repo, issue, prURL)
 }

--- a/internal/github/notifier.go
+++ b/internal/github/notifier.go
@@ -120,6 +120,12 @@ func (n *Notifier) CheckApproval(ctx context.Context, owner, repo string, issue 
 	return ApprovalResult{}, nil
 }
 
+// NotifyImplementationStarted posts a comment indicating implementation has begun.
+func (n *Notifier) NotifyImplementationStarted(ctx context.Context, owner, repo string, issue int) error {
+	body := "## Implementation Started\n\nThe plan has been approved. Implementation is now in progress..."
+	return n.postComment(ctx, owner, repo, issue, body)
+}
+
 // NotifyComplete posts the completion message with PR link.
 func (n *Notifier) NotifyComplete(ctx context.Context, owner, repo string, issue int, prURL string) error {
 	body := fmt.Sprintf("## Task Complete\n\nPull request created: %s", prURL)

--- a/internal/github/notifier_test.go
+++ b/internal/github/notifier_test.go
@@ -312,6 +312,31 @@ func TestCheckApproval_NoReactionsNoComments(t *testing.T) {
 	}
 }
 
+func TestNotifyImplementationStarted(t *testing.T) {
+	ts, fg := newFakeGitHub()
+	defer ts.Close()
+
+	n := testNotifier(t, ts.URL)
+	ctx := context.Background()
+
+	if err := n.NotifyImplementationStarted(ctx, "owner", "repo", 1); err != nil {
+		t.Fatal(err)
+	}
+
+	fg.mu.Lock()
+	defer fg.mu.Unlock()
+	if len(fg.comments) != 1 {
+		t.Fatalf("expected 1 comment, got %d", len(fg.comments))
+	}
+	body := fg.comments[0].GetBody()
+	if !strings.Contains(body, "Implementation Started") {
+		t.Error("comment should contain implementation started header")
+	}
+	if !strings.Contains(body, "in progress") {
+		t.Error("comment should contain in progress message")
+	}
+}
+
 func TestNotifyComplete(t *testing.T) {
 	ts, fg := newFakeGitHub()
 	defer ts.Close()

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -15,6 +15,7 @@ import (
 type Notifier interface {
 	NotifyPlanReady(ctx context.Context, owner, repo string, issue int, plan string) (commentID int64, err error)
 	CheckApproval(ctx context.Context, owner, repo string, issue int, commentID int64) (approved bool, feedback string, err error)
+	NotifyImplementationStarted(ctx context.Context, owner, repo string, issue int) error
 	NotifyComplete(ctx context.Context, owner, repo string, issue int, prURL string) error
 	NotifyFailed(ctx context.Context, owner, repo string, issue int, reason string) error
 }
@@ -184,6 +185,13 @@ func (o *Orchestrator) processApprovedTasks(ctx context.Context) error {
 			continue
 		}
 		o.publishEvent(t.ID, "task.updated")
+
+		// For GitHub tasks, post implementation-started comment (non-fatal).
+		if o.isGitHubTask(t) {
+			if err := o.config.Notifier.NotifyImplementationStarted(ctx, *t.GithubOwner, *t.GithubRepo, *t.GithubIssue); err != nil {
+				o.logger.Error("notify implementation started", "task_id", t.ID, "error", err)
+			}
+		}
 
 		go o.runImplement(ctx, t, workspace)
 	}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -604,14 +604,15 @@ func TestMultipleTasksQueueing(t *testing.T) {
 // --- mock notifier ---
 
 type mockNotifier struct {
-	mu               sync.Mutex
-	planReadyCalls   []string
-	checkCalls       []string
-	completeCalls    []string
-	failedCalls      []string
-	planReadyResult  int64
-	checkApproved    bool
-	checkFeedback    string
+	mu                      sync.Mutex
+	planReadyCalls          []string
+	checkCalls              []string
+	implStartedCalls        []string
+	completeCalls           []string
+	failedCalls             []string
+	planReadyResult         int64
+	checkApproved           bool
+	checkFeedback           string
 }
 
 func newMockNotifier() *mockNotifier {
@@ -630,6 +631,13 @@ func (m *mockNotifier) CheckApproval(ctx context.Context, owner, repo string, is
 	defer m.mu.Unlock()
 	m.checkCalls = append(m.checkCalls, fmt.Sprintf("%s/%s#%d@%d", owner, repo, issue, commentID))
 	return m.checkApproved, m.checkFeedback, nil
+}
+
+func (m *mockNotifier) NotifyImplementationStarted(ctx context.Context, owner, repo string, issue int) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.implStartedCalls = append(m.implStartedCalls, fmt.Sprintf("%s/%s#%d", owner, repo, issue))
+	return nil
 }
 
 func (m *mockNotifier) NotifyComplete(ctx context.Context, owner, repo string, issue int, prURL string) error {
@@ -1147,5 +1155,123 @@ func TestWaitForAgentReady_Timeout(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "timed out") {
 		t.Fatalf("expected timeout message, got: %v", err)
+	}
+}
+
+func TestExtractPRUrl(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantURL  string
+		wantNum  int
+	}{
+		{"empty", "", "", 0},
+		{"no match", "all done, pushed to origin", "", 0},
+		{"gh pr create output", "https://github.com/user/repo/pull/42\n", "https://github.com/user/repo/pull/42", 42},
+		{"embedded in text", "Created PR: https://github.com/org/project/pull/123 done", "https://github.com/org/project/pull/123", 123},
+		{"multiple matches returns first", "https://github.com/a/b/pull/1\nhttps://github.com/a/b/pull/2", "https://github.com/a/b/pull/1", 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url, num := extractPRUrl(tt.input)
+			if url != tt.wantURL {
+				t.Errorf("extractPRUrl() url = %q, want %q", url, tt.wantURL)
+			}
+			if num != tt.wantNum {
+				t.Errorf("extractPRUrl() num = %d, want %d", num, tt.wantNum)
+			}
+		})
+	}
+}
+
+func TestRunImplement_CapturesPRUrl(t *testing.T) {
+	exec := newMockExecutor()
+	exec.sshFunc = func(ctx context.Context, workspace, command string, stdout, stderr io.Writer) (*coder.SSHResult, error) {
+		if !strings.Contains(command, "test -d") {
+			_, _ = fmt.Fprint(stdout, "Created branch feat/foo\nhttps://github.com/test/repo/pull/99\n")
+		}
+		return &coder.SSHResult{ExitCode: 0}, nil
+	}
+
+	o, s := testOrchestrator(t, exec, nil)
+	ctx := context.Background()
+
+	task := createTask(t, s, "pr capture")
+	task.Status = StatusImplementing
+	task.Plan = strPtr("the plan")
+	task.PlanFeedback = strPtr("approved")
+	_ = s.UpdateTask(ctx, task.ID, task)
+
+	ws, _ := o.pool.Acquire(task.ID)
+	o.runImplement(ctx, task, ws)
+
+	updated, _ := s.GetTask(ctx, task.ID)
+	if updated.Status != StatusComplete {
+		t.Fatalf("expected complete, got %s", updated.Status)
+	}
+	if updated.PRUrl == nil || *updated.PRUrl != "https://github.com/test/repo/pull/99" {
+		t.Fatalf("expected PR URL, got %v", updated.PRUrl)
+	}
+	if updated.PRNumber == nil || *updated.PRNumber != 99 {
+		t.Fatalf("expected PR number 99, got %v", updated.PRNumber)
+	}
+}
+
+func TestProcessApprovedTasks_GitHubNotifyImplementationStarted(t *testing.T) {
+	exec := newMockExecutor()
+	notifier := newMockNotifier()
+	notifier.checkApproved = true
+
+	o, s := testOrchestrator(t, exec, nil)
+	o.config.Notifier = notifier
+	ctx := context.Background()
+
+	task := createGitHubTask(t, s, "github impl started")
+	task.Status = StatusAwaitingApproval
+	task.Plan = strPtr("the plan")
+	commentID := 42
+	task.PlanCommentID = &commentID
+	_ = s.UpdateTask(ctx, task.ID, task)
+
+	if err := o.processApprovedTasks(ctx); err != nil {
+		t.Fatal(err)
+	}
+	waitForStatus(t, s, task.ID, StatusComplete, 5*time.Second)
+
+	notifier.mu.Lock()
+	defer notifier.mu.Unlock()
+	if len(notifier.implStartedCalls) != 1 {
+		t.Fatalf("expected 1 impl started call, got %d", len(notifier.implStartedCalls))
+	}
+	if notifier.implStartedCalls[0] != "test/repo#1" {
+		t.Fatalf("unexpected call: %s", notifier.implStartedCalls[0])
+	}
+}
+
+func TestBuildImplementPrompt_RunTests(t *testing.T) {
+	task := &store.Task{
+		Plan:     strPtr("the plan"),
+		RunTests: true,
+	}
+	prompt := buildImplementPrompt(task)
+	if !strings.Contains(prompt, "Run the project's test suite") {
+		t.Fatalf("expected test instruction, got: %s", prompt)
+	}
+	if strings.Contains(prompt, "Create a new branch, make all changes, commit, and push") {
+		t.Fatal("should not contain old explicit git instructions")
+	}
+}
+
+func TestBuildImplementPrompt_NoTests(t *testing.T) {
+	task := &store.Task{
+		Plan:     strPtr("the plan"),
+		RunTests: false,
+	}
+	prompt := buildImplementPrompt(task)
+	if strings.Contains(prompt, "Run the project's test suite") {
+		t.Fatal("should not contain test instruction when RunTests is false")
+	}
+	if !strings.Contains(prompt, "Follow your git workflow rules") {
+		t.Fatalf("expected git workflow rules reference, got: %s", prompt)
 	}
 }

--- a/internal/orchestrator/steps.go
+++ b/internal/orchestrator/steps.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -124,6 +126,14 @@ func (o *Orchestrator) stepImplement(ctx context.Context, task *store.Task, work
 
 	if err != nil {
 		return fmt.Errorf("implement step: %w\n\nstderr tail:\n%s", err, stderr.Tail(20))
+	}
+
+	// Parse PR URL from output (gh pr create prints the URL to stdout).
+	if prURL, prNumber := extractPRUrl(stdout.String()); prURL != "" {
+		task.PRUrl = &prURL
+		if prNumber > 0 {
+			task.PRNumber = &prNumber
+		}
 	}
 	return nil
 }
@@ -282,11 +292,27 @@ func buildPlanPrompt(task *store.Task) string {
 }
 
 func buildImplementPrompt(task *store.Task) string {
-	return fmt.Sprintf(
+	prompt := fmt.Sprintf(
 		"The plan has been approved. Implement it now. "+
-			"Create a new branch, make all changes, commit, and push.\n\nApproved plan:\n%s",
+			"Follow your git workflow rules for branching, committing, and PR creation.\n\nApproved plan:\n%s",
 		stringVal(task.Plan),
 	)
+	if task.RunTests {
+		prompt += "\n\nIMPORTANT: Run the project's test suite before committing to verify nothing is broken."
+	}
+	return prompt
+}
+
+var prURLRe = regexp.MustCompile(`https://github\.com/[^/]+/[^/]+/pull/(\d+)`)
+
+// extractPRUrl finds a GitHub PR URL in the output and returns the URL and PR number.
+func extractPRUrl(output string) (string, int) {
+	m := prURLRe.FindStringSubmatch(output)
+	if m == nil {
+		return "", 0
+	}
+	num, _ := strconv.Atoi(m[1])
+	return m[0], num
 }
 
 func stringVal(s *string) string {


### PR DESCRIPTION
## Summary

- Adds `NotifyImplementationStarted` to the Notifier interface, posting an "Implementation Started" comment on GitHub issues when a plan is approved and implementation begins
- Updates `buildImplementPrompt` to reference git workflow rules instead of specifying explicit git steps (`Create a new branch, make all changes, commit, and push`), removing the conflict with `~/.claude/rules/git-workflow.md` that prevented PR creation
- Adds `extractPRUrl` helper to parse the PR URL from `gh pr create` output in `stepImplement`, so `NotifyComplete` posts the actual PR link
- Appends a test-suite instruction to the prompt when `task.RunTests` is true

## Test plan

- [x] `go test ./...` — all existing and new tests pass
- [x] Unit tests for `extractPRUrl` (empty, no match, standard URL, embedded, multiple)
- [x] Test for PR URL capture in `TestRunImplement_CapturesPRUrl`
- [x] Test for implementation-started notification in `TestProcessApprovedTasks_GitHubNotifyImplementationStarted`
- [x] Tests for `buildImplementPrompt` with and without `RunTests`
- [x] Integration test for `NotifyImplementationStarted` against fake GitHub API
- [ ] Deploy and trigger end-to-end flow on a test issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)