### PR TITLE
fix: add --allowedTools to implement step for write tool access

### DIFF
--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -344,6 +344,9 @@ func TestRunImplement_Success(t *testing.T) {
 	if strings.Contains(exec.sshCalls[1].Command, "--permission-mode plan") {
 		t.Fatalf("implement command should not contain --permission-mode plan, got: %s", exec.sshCalls[1].Command)
 	}
+	if !strings.Contains(exec.sshCalls[1].Command, "--allowedTools") {
+		t.Fatalf("implement command should contain --allowedTools flag, got: %s", exec.sshCalls[1].Command)
+	}
 }
 
 func TestRunImplement_Failure(t *testing.T) {

--- a/internal/orchestrator/steps.go
+++ b/internal/orchestrator/steps.go
@@ -114,7 +114,7 @@ func (o *Orchestrator) stepImplement(ctx context.Context, task *store.Task, work
 	}
 
 	cmd := fmt.Sprintf(
-		"cd %s && git checkout %s > /dev/null 2>&1 && TERM=dumb claude -p %s --print",
+		"cd %s && git checkout %s > /dev/null 2>&1 && TERM=dumb claude -p %s --print --allowedTools 'Bash,Edit,Write'",
 		shellQuote(repoDir),
 		shellQuote(task.BaseBranch),
 		shellQuote(buildImplementPrompt(task)),


### PR DESCRIPTION
## Summary
- Adds `--allowedTools 'Bash,Edit,Write'` to the Claude CLI command in `stepImplement()`
- This fixes the implement agent being unable to create branches, edit files, commit, push, or open PRs in non-interactive mode
- The `settings.json` deny list still blocks dangerous patterns (rm -rf, piped downloads)

## Test plan
- [x] `go test ./...` passes
- [ ] Deploy and trigger end-to-end flow — agent should now create a branch, commit, push, and open a PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)