### PR TITLE
feat: sort dashboard agents by status and name

### DIFF
--- a/internal/server/handlers_agents.go
+++ b/internal/server/handlers_agents.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"net/http"
+	"sort"
 )
 
 type AgentInfo struct {
@@ -32,5 +33,22 @@ func (s *Server) handleListAgents(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
+	sort.Slice(agents, func(i, j int) bool {
+		pi, pj := statusPriority(agents[i].WorkspaceStatus), statusPriority(agents[j].WorkspaceStatus)
+		if pi != pj {
+			return pi < pj
+		}
+		return agents[i].Name < agents[j].Name
+	})
+
 	writeJSON(w, http.StatusOK, agents)
+}
+
+func statusPriority(status string) int {
+	switch status {
+	case "running", "starting", "stopping":
+		return 0
+	default:
+		return 1
+	}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -673,6 +673,15 @@ func TestStreamLogs_ActiveTask(t *testing.T) {
 	}
 }
 
+func testServerWithPool(t *testing.T, exec coder.WorkspaceExecutor, agents []string) (*Server, *store.Store) {
+	t.Helper()
+	s := testStore(t)
+	pool := coder.NewPool(agents)
+	hub := NewHub()
+	srv := New(s, pool, exec, hub, slog.Default())
+	return srv, s
+}
+
 // --- agents test ---
 
 func TestListAgents(t *testing.T) {
@@ -738,6 +747,44 @@ func TestListAgents_ExecutorError(t *testing.T) {
 	// Should still return pool slots, just without workspace status.
 	if len(agents) != 2 {
 		t.Fatalf("expected 2 agents, got %d", len(agents))
+	}
+}
+
+func TestListAgents_SortOrder(t *testing.T) {
+	exec := &mockExecutor{
+		workspaces: []coder.WorkspaceInfo{
+			{Name: "agent-1", Status: coder.WorkspaceStatusStopped},
+			{Name: "agent-2", Status: coder.WorkspaceStatusRunning},
+			{Name: "agent-3", Status: coder.WorkspaceStatusStopped},
+			{Name: "agent-4", Status: coder.WorkspaceStatusRunning},
+		},
+	}
+	srv, _ := testServerWithPool(t, exec, []string{"agent-1", "agent-2", "agent-3", "agent-4"})
+	ts := httptest.NewServer(srv.Routes())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/api/v1/agents")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var agents []AgentInfo
+	_ = json.NewDecoder(resp.Body).Decode(&agents)
+	if len(agents) != 4 {
+		t.Fatalf("expected 4 agents, got %d", len(agents))
+	}
+
+	// Expect: running first (alphabetical), then stopped (alphabetical).
+	expected := []string{"agent-2", "agent-4", "agent-1", "agent-3"}
+	for i, name := range expected {
+		if agents[i].Name != name {
+			t.Fatalf("agents[%d]: expected %q, got %q", i, name, agents[i].Name)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Sort agents in `/api/v1/agents` response so active workspaces (`running`, `starting`, `stopping`) appear first, followed by inactive ones
- Within each group, agents are sorted alphabetically by name
- Fixes non-deterministic ordering caused by Go map iteration in `Pool.Status()`

## Changes
- **`internal/server/handlers_agents.go`**: Added `sort.Slice` after building the agents slice, with a `statusPriority` helper that returns `0` for active statuses and `1` for all others
- **`internal/server/server_test.go`**: Added `TestListAgents_SortOrder` test with 4 agents (2 running, 2 stopped) verifying correct sort order; added `testServerWithPool` helper for custom pool sizes

## Test plan
- [ ] Run `go test ./internal/server/...` — existing tests pass, new `TestListAgents_SortOrder` passes
- [ ] Load dashboard and verify agents appear with running agents first (alphabetical), then stopped (alphabetical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)