### PR TITLE
fix: retry plan step on empty Claude CLI output

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -33,6 +33,7 @@ type Config struct {
 	VerifyRetryDelay       time.Duration // delay between verifyRepoDir retries (default 5s)
 	AgentReadyTimeout      time.Duration // max wait for agent lifecycle "ready" (default 2m)
 	AgentReadyPollInterval time.Duration // poll interval for agent readiness (default 5s)
+	PlanRetries            int           // retries on empty plan output (default 1; total attempts = 1 + PlanRetries)
 	OnEvent                func(taskID, eventType string)
 	Notifier               Notifier
 }
@@ -44,6 +45,7 @@ func DefaultConfig() Config {
 		VerifyRetryDelay:       5 * time.Second,
 		AgentReadyTimeout:      2 * time.Minute,
 		AgentReadyPollInterval: 5 * time.Second,
+		PlanRetries:            1,
 	}
 }
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1373,5 +1374,82 @@ func TestProcessApprovedTasks_GitHubFeedbackPreservesDecisions(t *testing.T) {
 	}
 	if updated.Decisions == nil || *updated.Decisions != "- [x] SQLite" {
 		t.Fatalf("expected decisions preserved, got %v", updated.Decisions)
+	}
+}
+
+func TestStepPlan_RetryOnEmptyOutput(t *testing.T) {
+	exec := newMockExecutor()
+
+	var claudeCalls atomic.Int32
+	exec.sshFunc = func(ctx context.Context, workspace, command string, stdout, stderr io.Writer) (*coder.SSHResult, error) {
+		if strings.Contains(command, "test -d") {
+			return &coder.SSHResult{ExitCode: 0}, nil
+		}
+		// First claude call returns empty, second returns real output.
+		n := claudeCalls.Add(1)
+		if n == 1 {
+			return &coder.SSHResult{ExitCode: 0}, nil
+		}
+		_, _ = fmt.Fprint(stdout, "the generated plan")
+		return &coder.SSHResult{ExitCode: 0}, nil
+	}
+
+	s := testStore(t)
+	pool := coder.NewPool(coder.DefaultWorkspaces)
+	o := New(s, exec, pool, slog.Default(), Config{
+		TickInterval:           50 * time.Millisecond,
+		VerifyRetryDelay:       10 * time.Millisecond,
+		AgentReadyTimeout:      2 * time.Second,
+		AgentReadyPollInterval: 10 * time.Millisecond,
+		PlanRetries:            1,
+	})
+
+	ctx := context.Background()
+	task := createTask(t, s, "retry plan")
+
+	err := o.stepPlan(ctx, task, "ws-1")
+	if err != nil {
+		t.Fatalf("expected stepPlan to succeed after retry, got: %v", err)
+	}
+	if task.Plan == nil || *task.Plan != "the generated plan" {
+		t.Fatalf("expected plan to be set, got: %v", task.Plan)
+	}
+	if claudeCalls.Load() != 2 {
+		t.Fatalf("expected 2 claude SSH calls, got %d", claudeCalls.Load())
+	}
+}
+
+func TestStepPlan_FailsAfterMaxRetries(t *testing.T) {
+	exec := newMockExecutor()
+	exec.sshFunc = func(ctx context.Context, workspace, command string, stdout, stderr io.Writer) (*coder.SSHResult, error) {
+		if strings.Contains(command, "test -d") {
+			return &coder.SSHResult{ExitCode: 0}, nil
+		}
+		// Always return empty output.
+		return &coder.SSHResult{ExitCode: 0}, nil
+	}
+
+	s := testStore(t)
+	pool := coder.NewPool(coder.DefaultWorkspaces)
+	o := New(s, exec, pool, slog.Default(), Config{
+		TickInterval:           50 * time.Millisecond,
+		VerifyRetryDelay:       10 * time.Millisecond,
+		AgentReadyTimeout:      2 * time.Second,
+		AgentReadyPollInterval: 10 * time.Millisecond,
+		PlanRetries:            1,
+	})
+
+	ctx := context.Background()
+	task := createTask(t, s, "fail plan")
+
+	err := o.stepPlan(ctx, task, "ws-1")
+	if err == nil {
+		t.Fatal("expected stepPlan to fail after max retries")
+	}
+	if !strings.Contains(err.Error(), "empty output after 2 attempts") {
+		t.Fatalf("expected empty output error, got: %v", err)
+	}
+	if task.Plan != nil {
+		t.Fatalf("expected plan to remain nil, got: %v", *task.Plan)
 	}
 }

--- a/internal/orchestrator/steps.go
+++ b/internal/orchestrator/steps.go
@@ -65,10 +65,10 @@ func (o *Orchestrator) verifyRepoDir(ctx context.Context, workspace, repoDir str
 
 // stepPlan invokes Claude CLI to produce a plan. The repo is already cloned
 // by the workspace template via the repo_url parameter.
+//
+// Retries up to PlanRetries times on empty output (transient Claude CLI issue).
+// SSH errors are not retried as they indicate infrastructure failures.
 func (o *Orchestrator) stepPlan(ctx context.Context, task *store.Task, workspace string) error {
-	stdout := o.newLogWriter(ctx, task.ID, "plan", "stdout")
-	stderr := o.newLogWriter(ctx, task.ID, "plan", "stderr")
-
 	repoDir := "/home/coder/" + repoName(task.RepoURL)
 	if err := o.verifyRepoDir(ctx, workspace, repoDir); err != nil {
 		return err
@@ -81,25 +81,47 @@ func (o *Orchestrator) stepPlan(ctx context.Context, task *store.Task, workspace
 		shellQuote(buildPlanPrompt(task)),
 	)
 
-	_, err := o.executor.SSH(ctx, workspace, cmd, stdout, stderr)
-	_ = stdout.Flush()
-	_ = stderr.Flush()
-
-	o.logger.Info("plan step SSH completed",
-		"task_id", task.ID,
-		"stdout_len", len(stdout.String()),
-		"stderr_len", len(stderr.String()))
-
-	if err != nil {
-		return fmt.Errorf("plan step: %w\n\nstderr tail:\n%s", err, stderr.Tail(20))
+	maxAttempts := 1 + o.config.PlanRetries
+	if maxAttempts < 1 {
+		maxAttempts = 1
 	}
 
-	plan := stdout.String()
-	if strings.TrimSpace(plan) == "" {
-		return fmt.Errorf("plan step produced empty output\n\nstderr tail:\n%s\n\nstdout tail:\n%s", stderr.Tail(20), stdout.Tail(20))
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		stdout := o.newLogWriter(ctx, task.ID, "plan", "stdout")
+		stderr := o.newLogWriter(ctx, task.ID, "plan", "stderr")
+
+		_, err := o.executor.SSH(ctx, workspace, cmd, stdout, stderr)
+		_ = stdout.Flush()
+		_ = stderr.Flush()
+
+		o.logger.Info("plan step SSH completed",
+			"task_id", task.ID,
+			"attempt", attempt,
+			"max_attempts", maxAttempts,
+			"stdout_len", len(stdout.String()),
+			"stderr_len", len(stderr.String()))
+
+		if err != nil {
+			return fmt.Errorf("plan step: %w\n\nstderr tail:\n%s", err, stderr.Tail(20))
+		}
+
+		plan := stdout.String()
+		if strings.TrimSpace(plan) != "" {
+			task.Plan = &plan
+			return nil
+		}
+
+		if attempt < maxAttempts {
+			o.logger.Warn("plan step produced empty output, retrying",
+				"task_id", task.ID, "attempt", attempt, "max_attempts", maxAttempts)
+			continue
+		}
+
+		return fmt.Errorf("plan step produced empty output after %d attempts\n\nstderr tail:\n%s\n\nstdout tail:\n%s",
+			maxAttempts, stderr.Tail(20), stdout.Tail(20))
 	}
-	task.Plan = &plan
-	return nil
+
+	return nil // unreachable
 }
 
 // stepImplement invokes Claude CLI to implement the approved plan.


### PR DESCRIPTION
## Summary
- Wraps the Claude SSH call in `stepPlan` with a retry loop (max 2 attempts by default) to recover from transient empty-output failures
- Adds `PlanRetries` config field (default 1) to `Config` struct for testability
- Only retries on empty output — SSH errors are returned immediately as infrastructure failures

## Test plan
- [x] `TestStepPlan_RetryOnEmptyOutput` — mock returns empty on first call, real output on second; verifies plan succeeds
- [x] `TestStepPlan_FailsAfterMaxRetries` — mock always returns empty; verifies step fails with descriptive error after max attempts
- [x] All existing tests pass (`go test ./...`)

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)