### PR TITLE
feat: add task title, auto-create GitHub issues, display title in UI

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -76,6 +76,10 @@ func main() {
 		serverOpts = append(serverOpts, server.WithAllowedUsers(strings.Split(users, ",")))
 	}
 
+	// Auto-create GitHub issues for new tasks (default: true).
+	createIssues := envOr("CREATE_GITHUB_ISSUES", "true")
+	serverOpts = append(serverOpts, server.WithAutoCreateIssues(createIssues == "true"))
+
 	if appID != "" && installationID != "" && privateKey != "" {
 		parsedAppID, err := strconv.ParseInt(appID, 10, 64)
 		if err != nil {

--- a/internal/server/handlers_agents.go
+++ b/internal/server/handlers_agents.go
@@ -8,6 +8,7 @@ import (
 type AgentInfo struct {
 	Name            string `json:"name"`
 	TaskID          string `json:"task_id"`
+	TaskTitle       string `json:"task_title"`
 	WorkspaceStatus string `json:"workspace_status"`
 }
 
@@ -26,11 +27,17 @@ func (s *Server) handleListAgents(w http.ResponseWriter, r *http.Request) {
 
 	agents := make([]AgentInfo, 0, len(slots))
 	for _, slot := range slots {
-		agents = append(agents, AgentInfo{
+		info := AgentInfo{
 			Name:            slot.Name,
 			TaskID:          slot.TaskID,
 			WorkspaceStatus: statusMap[slot.Name],
-		})
+		}
+		if slot.TaskID != "" {
+			if task, err := s.store.GetTask(r.Context(), slot.TaskID); err == nil && task.Title != nil {
+				info.TaskTitle = *task.Title
+			}
+		}
+		agents = append(agents, info)
 	}
 
 	sort.Slice(agents, func(i, j int) bool {

--- a/internal/server/handlers_config.go
+++ b/internal/server/handlers_config.go
@@ -4,10 +4,12 @@ import "net/http"
 
 type ConfigResponse struct {
 	GitHubConfigured bool `json:"github_configured"`
+	AutoCreateIssues bool `json:"auto_create_issues"`
 }
 
 func (s *Server) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, ConfigResponse{
 		GitHubConfigured: s.githubClient != nil,
+		AutoCreateIssues: s.autoCreateIssues,
 	})
 }

--- a/internal/server/handlers_config_test.go
+++ b/internal/server/handlers_config_test.go
@@ -30,6 +30,9 @@ func TestGetConfig_WithoutGitHub(t *testing.T) {
 	if config.GitHubConfigured {
 		t.Fatal("expected github_configured to be false")
 	}
+	if config.AutoCreateIssues {
+		t.Fatal("expected auto_create_issues to be false by default")
+	}
 }
 
 func TestGetConfig_WithGitHub(t *testing.T) {

--- a/internal/server/handlers_github.go
+++ b/internal/server/handlers_github.go
@@ -108,7 +108,9 @@ func (s *Server) handleIssuesEvent(r *http.Request, event *gogithub.IssuesEvent)
 		baseBranch = "main"
 	}
 
+	issueTitle := issue.GetTitle()
 	task := &store.Task{
+		Title:       &issueTitle,
 		Prompt:      prompt,
 		RepoURL:     strings.TrimSuffix(repo.GetCloneURL(), ".git"),
 		BaseBranch:  baseBranch,

--- a/internal/server/handlers_github_test.go
+++ b/internal/server/handlers_github_test.go
@@ -150,6 +150,9 @@ func TestGitHubWebhook_IssuesLabeled_CreatesTask(t *testing.T) {
 	}
 
 	task := tasks[0]
+	if task.Title == nil || *task.Title != "Add caching layer" {
+		t.Fatalf("expected title 'Add caching layer', got %v", task.Title)
+	}
 	if task.SourceType != "github" {
 		t.Fatalf("expected source_type 'github', got %q", task.SourceType)
 	}

--- a/internal/server/handlers_tasks.go
+++ b/internal/server/handlers_tasks.go
@@ -16,10 +16,10 @@ import (
 )
 
 type CreateTaskRequest struct {
-	Prompt      string `json:"prompt"`
-	RepoURL     string `json:"repo_url"`
-	BaseBranch  string `json:"base_branch"`
-	CreateIssue bool   `json:"create_issue"`
+	Title      string `json:"title"`
+	Prompt     string `json:"prompt"`
+	RepoURL    string `json:"repo_url"`
+	BaseBranch string `json:"base_branch"`
 }
 
 type ApproveRequest struct {
@@ -58,35 +58,34 @@ func (s *Server) handleCreateTask(w http.ResponseWriter, r *http.Request) {
 		SourceType: "api",
 		SessionID:  uuid.New().String(),
 	}
+	if req.Title != "" {
+		task.Title = &req.Title
+	}
 
-	if req.CreateIssue {
-		if s.githubClient == nil {
-			writeError(w, http.StatusBadRequest, "GitHub integration not configured")
-			return
-		}
-
+	// Auto-create GitHub issue when configured and repo is on GitHub.
+	if s.autoCreateIssues && s.githubClient != nil {
 		owner, repo, err := parseGitHubRepo(req.RepoURL)
-		if err != nil || owner == "" {
-			writeError(w, http.StatusBadRequest, "repo_url must be a valid GitHub repository URL")
-			return
+		if err == nil && owner != "" {
+			issueTitle := req.Title
+			issueBody := req.Prompt
+			if issueTitle == "" {
+				issueTitle, issueBody = splitPromptForIssue(req.Prompt)
+			}
+			issue, _, err := s.githubClient.Issues.Create(r.Context(), owner, repo, &gogithub.IssueRequest{
+				Title:  &issueTitle,
+				Body:   &issueBody,
+				Labels: &[]string{aiTaskLabel},
+			})
+			if err != nil {
+				s.logger.Error("auto-create github issue", "error", err)
+				// Non-fatal: continue creating the task without an issue.
+			} else {
+				issueNumber := issue.GetNumber()
+				task.GithubOwner = &owner
+				task.GithubRepo = &repo
+				task.GithubIssue = &issueNumber
+			}
 		}
-
-		title, body := splitPromptForIssue(req.Prompt)
-		issue, _, err := s.githubClient.Issues.Create(r.Context(), owner, repo, &gogithub.IssueRequest{
-			Title:  &title,
-			Body:   &body,
-			Labels: &[]string{aiTaskLabel},
-		})
-		if err != nil {
-			s.logger.Error("create github issue", "error", err)
-			writeError(w, http.StatusBadGateway, "failed to create GitHub issue")
-			return
-		}
-
-		issueNumber := issue.GetNumber()
-		task.GithubOwner = &owner
-		task.GithubRepo = &repo
-		task.GithubIssue = &issueNumber
 	}
 
 	if err := s.store.CreateTask(r.Context(), task); err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -19,8 +19,9 @@ type Server struct {
 	logger        *slog.Logger
 	githubClient  *ghclient.Client // nil if GitHub not configured
 	webhookSecret []byte           // nil if GitHub not configured
-	allowedUsers  []string         // empty = allow all
-	repoCache     repoCache
+	allowedUsers     []string // empty = allow all
+	autoCreateIssues bool
+	repoCache        repoCache
 }
 
 func New(store *store.Store, pool *coder.Pool, executor coder.WorkspaceExecutor, hub *Hub, logger *slog.Logger, opts ...Option) *Server {
@@ -45,6 +46,13 @@ type Option func(*Server)
 func WithAllowedUsers(users []string) Option {
 	return func(s *Server) {
 		s.allowedUsers = users
+	}
+}
+
+// WithAutoCreateIssues enables automatic GitHub issue creation for new tasks.
+func WithAutoCreateIssues(enabled bool) Option {
+	return func(s *Server) {
+		s.autoCreateIssues = enabled
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -15,8 +15,10 @@ import (
 	"testing"
 	"time"
 
+	gogithub "github.com/google/go-github/v83/github"
 	"github.com/gorilla/websocket"
 	"github.com/jcwearn/agent-orchestrator/internal/coder"
+	ghclient "github.com/jcwearn/agent-orchestrator/internal/github"
 	"github.com/jcwearn/agent-orchestrator/internal/store"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -125,7 +127,7 @@ func TestCreateTask_Success(t *testing.T) {
 	defer ts.Close()
 	client := authenticatedClient(t, s, ts.URL)
 
-	body := `{"prompt": "implement feature X", "repo_url": "https://github.com/test/repo"}`
+	body := `{"title": "Feature X", "prompt": "implement feature X", "repo_url": "https://github.com/test/repo"}`
 	resp, err := client.Post(ts.URL+"/api/v1/tasks", "application/json", strings.NewReader(body))
 	if err != nil {
 		t.Fatal(err)
@@ -142,6 +144,9 @@ func TestCreateTask_Success(t *testing.T) {
 	}
 	if task.ID == "" {
 		t.Fatal("expected task ID")
+	}
+	if task.Title == nil || *task.Title != "Feature X" {
+		t.Fatalf("expected title 'Feature X', got %v", task.Title)
 	}
 	if task.Status != "queued" {
 		t.Fatalf("expected status 'queued', got %q", task.Status)
@@ -962,9 +967,27 @@ func TestCreateTask_InvalidJSON(t *testing.T) {
 	}
 }
 
-// --- create task with create_issue tests ---
+// --- auto-create issue tests ---
 
-func TestCreateTask_WithCreateIssue(t *testing.T) {
+func testServerWithGitHubAutoIssues(t *testing.T, ghServerURL string) (*Server, *store.Store) {
+	t.Helper()
+	s := testStore(t)
+	pool := coder.NewPool([]string{"agent-1", "agent-2"})
+	exec := &mockExecutor{}
+	hub := NewHub()
+
+	gc := gogithub.NewClient(nil)
+	gc, _ = gc.WithEnterpriseURLs(ghServerURL+"/", ghServerURL+"/")
+	client := &ghclient.Client{Client: gc}
+
+	srv := New(s, pool, exec, hub, slog.Default(),
+		WithGitHub(client, []byte(testWebhookSecret)),
+		WithAutoCreateIssues(true),
+	)
+	return srv, s
+}
+
+func TestCreateTask_AutoCreateIssue(t *testing.T) {
 	var createdTitle, createdBody string
 	var createdLabels []string
 	ghMux := http.NewServeMux()
@@ -984,12 +1007,12 @@ func TestCreateTask_WithCreateIssue(t *testing.T) {
 	ghServer := httptest.NewServer(ghMux)
 	defer ghServer.Close()
 
-	srv, s := testServerWithGitHub(t, ghServer.URL)
+	srv, s := testServerWithGitHubAutoIssues(t, ghServer.URL)
 	ts := httptest.NewServer(srv.Routes())
 	defer ts.Close()
 	client := authenticatedClient(t, s, ts.URL)
 
-	body := `{"prompt": "Add caching layer\n\nWe need Redis.", "repo_url": "https://github.com/testowner/testrepo", "create_issue": true}`
+	body := `{"title": "Add caching layer", "prompt": "We need Redis.", "repo_url": "https://github.com/testowner/testrepo"}`
 	resp, err := client.Post(ts.URL+"/api/v1/tasks", "application/json", strings.NewReader(body))
 	if err != nil {
 		t.Fatal(err)
@@ -1002,6 +1025,9 @@ func TestCreateTask_WithCreateIssue(t *testing.T) {
 
 	var task store.Task
 	_ = json.NewDecoder(resp.Body).Decode(&task)
+	if task.Title == nil || *task.Title != "Add caching layer" {
+		t.Fatalf("expected title 'Add caching layer', got %v", task.Title)
+	}
 	if task.GithubOwner == nil || *task.GithubOwner != "testowner" {
 		t.Fatalf("expected github_owner 'testowner', got %v", task.GithubOwner)
 	}
@@ -1025,41 +1051,58 @@ func TestCreateTask_WithCreateIssue(t *testing.T) {
 	}
 }
 
-func TestCreateTask_WithCreateIssue_NonGitHubURL(t *testing.T) {
+func TestCreateTask_AutoCreateIssue_Disabled(t *testing.T) {
 	ghServer := httptest.NewServer(http.NewServeMux())
 	defer ghServer.Close()
 
+	// Use testServerWithGitHub which does NOT set autoCreateIssues.
 	srv, s := testServerWithGitHub(t, ghServer.URL)
 	ts := httptest.NewServer(srv.Routes())
 	defer ts.Close()
 	client := authenticatedClient(t, s, ts.URL)
 
-	body := `{"prompt": "do something", "repo_url": "https://gitlab.com/owner/repo", "create_issue": true}`
+	body := `{"title": "test", "prompt": "do something", "repo_url": "https://github.com/owner/repo"}`
 	resp, err := client.Post(ts.URL+"/api/v1/tasks", "application/json", strings.NewReader(body))
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", resp.StatusCode)
+	}
+
+	var task store.Task
+	_ = json.NewDecoder(resp.Body).Decode(&task)
+	if task.GithubIssue != nil {
+		t.Fatalf("expected no github issue when auto-create disabled, got %v", task.GithubIssue)
 	}
 }
 
-func TestCreateTask_WithCreateIssue_GitHubNotConfigured(t *testing.T) {
-	srv, s := testServer(t)
+func TestCreateTask_AutoCreateIssue_NonGitHubURL(t *testing.T) {
+	ghServer := httptest.NewServer(http.NewServeMux())
+	defer ghServer.Close()
+
+	srv, s := testServerWithGitHubAutoIssues(t, ghServer.URL)
 	ts := httptest.NewServer(srv.Routes())
 	defer ts.Close()
 	client := authenticatedClient(t, s, ts.URL)
 
-	body := `{"prompt": "do something", "repo_url": "https://github.com/owner/repo", "create_issue": true}`
+	body := `{"title": "test", "prompt": "do something", "repo_url": "https://gitlab.com/owner/repo"}`
 	resp, err := client.Post(ts.URL+"/api/v1/tasks", "application/json", strings.NewReader(body))
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	// Should succeed — non-GitHub URL silently skips issue creation.
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", resp.StatusCode)
+	}
+
+	var task store.Task
+	_ = json.NewDecoder(resp.Body).Decode(&task)
+	if task.GithubIssue != nil {
+		t.Fatalf("expected no github issue for non-GitHub URL, got %v", task.GithubIssue)
 	}
 }

--- a/internal/store/migrations/004_task_title.sql
+++ b/internal/store/migrations/004_task_title.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tasks ADD COLUMN title TEXT;

--- a/internal/store/models.go
+++ b/internal/store/models.go
@@ -5,6 +5,7 @@ import "time"
 type Task struct {
 	ID            string     `json:"id"`
 	Status        string     `json:"status"`
+	Title         *string    `json:"title"`
 	Prompt        string     `json:"prompt"`
 	Plan          *string    `json:"plan"`
 	PlanFeedback  *string    `json:"plan_feedback"`

--- a/internal/store/tasks.go
+++ b/internal/store/tasks.go
@@ -12,7 +12,7 @@ import (
 
 func (s *Store) GetTaskByPRNumber(ctx context.Context, owner, repo string, prNumber int) (*Task, error) {
 	row := s.db.QueryRowContext(ctx, `SELECT
-		id, status, prompt, plan, plan_feedback, repo_url, base_branch,
+		id, status, title, prompt, plan, plan_feedback, repo_url, base_branch,
 		source_type, github_owner, github_repo, github_issue, session_id,
 		workspace_id, current_step, plan_comment_id, plan_revision,
 		pr_url, pr_number, run_tests, decisions,
@@ -33,7 +33,7 @@ func (s *Store) GetTaskByPRNumber(ctx context.Context, owner, repo string, prNum
 
 func (s *Store) GetTaskByGithubIssue(ctx context.Context, owner, repo string, issue int) (*Task, error) {
 	row := s.db.QueryRowContext(ctx, `SELECT
-		id, status, prompt, plan, plan_feedback, repo_url, base_branch,
+		id, status, title, prompt, plan, plan_feedback, repo_url, base_branch,
 		source_type, github_owner, github_repo, github_issue, session_id,
 		workspace_id, current_step, plan_comment_id, plan_revision,
 		pr_url, pr_number, run_tests, decisions,
@@ -64,19 +64,19 @@ func (s *Store) CreateTask(ctx context.Context, t *Task) error {
 
 	_, err := s.db.ExecContext(ctx, `
 		INSERT INTO tasks (
-			id, status, prompt, plan, plan_feedback, repo_url, base_branch,
+			id, status, title, prompt, plan, plan_feedback, repo_url, base_branch,
 			source_type, github_owner, github_repo, github_issue, session_id,
 			workspace_id, current_step, plan_comment_id, plan_revision,
 			pr_url, pr_number, run_tests, decisions,
 			created_at, started_at, completed_at, error_message
 		) VALUES (
-			?, ?, ?, ?, ?, ?, ?,
+			?, ?, ?, ?, ?, ?, ?, ?,
 			?, ?, ?, ?, ?,
 			?, ?, ?, ?,
 			?, ?, ?, ?,
 			?, ?, ?, ?
 		)`,
-		t.ID, t.Status, t.Prompt, t.Plan, t.PlanFeedback, t.RepoURL, t.BaseBranch,
+		t.ID, t.Status, t.Title, t.Prompt, t.Plan, t.PlanFeedback, t.RepoURL, t.BaseBranch,
 		t.SourceType, t.GithubOwner, t.GithubRepo, t.GithubIssue, t.SessionID,
 		t.WorkspaceID, t.CurrentStep, t.PlanCommentID, t.PlanRevision,
 		t.PRUrl, t.PRNumber, t.RunTests, t.Decisions,
@@ -93,7 +93,7 @@ func (s *Store) CreateTask(ctx context.Context, t *Task) error {
 
 func (s *Store) GetTask(ctx context.Context, id string) (*Task, error) {
 	row := s.db.QueryRowContext(ctx, `SELECT
-		id, status, prompt, plan, plan_feedback, repo_url, base_branch,
+		id, status, title, prompt, plan, plan_feedback, repo_url, base_branch,
 		source_type, github_owner, github_repo, github_issue, session_id,
 		workspace_id, current_step, plan_comment_id, plan_revision,
 		pr_url, pr_number, run_tests, decisions,
@@ -116,7 +116,7 @@ func (s *Store) ListTasks(ctx context.Context, status string) ([]Task, error) {
 
 	if status == "" {
 		rows, err = s.db.QueryContext(ctx, `SELECT
-			id, status, prompt, plan, plan_feedback, repo_url, base_branch,
+			id, status, title, prompt, plan, plan_feedback, repo_url, base_branch,
 			source_type, github_owner, github_repo, github_issue, session_id,
 			workspace_id, current_step, plan_comment_id, plan_revision,
 			pr_url, pr_number, run_tests, decisions,
@@ -124,7 +124,7 @@ func (s *Store) ListTasks(ctx context.Context, status string) ([]Task, error) {
 		FROM tasks ORDER BY created_at DESC`)
 	} else {
 		rows, err = s.db.QueryContext(ctx, `SELECT
-			id, status, prompt, plan, plan_feedback, repo_url, base_branch,
+			id, status, title, prompt, plan, plan_feedback, repo_url, base_branch,
 			source_type, github_owner, github_repo, github_issue, session_id,
 			workspace_id, current_step, plan_comment_id, plan_revision,
 			pr_url, pr_number, run_tests, decisions,
@@ -150,7 +150,7 @@ func (s *Store) ListTasks(ctx context.Context, status string) ([]Task, error) {
 func (s *Store) UpdateTask(ctx context.Context, id string, t *Task) error {
 	result, err := s.db.ExecContext(ctx, `
 		UPDATE tasks SET
-			status = ?, prompt = ?, plan = ?, plan_feedback = ?,
+			status = ?, title = ?, prompt = ?, plan = ?, plan_feedback = ?,
 			repo_url = ?, base_branch = ?, source_type = ?,
 			github_owner = ?, github_repo = ?, github_issue = ?,
 			session_id = ?, workspace_id = ?, current_step = ?,
@@ -158,7 +158,7 @@ func (s *Store) UpdateTask(ctx context.Context, id string, t *Task) error {
 			pr_url = ?, pr_number = ?, run_tests = ?, decisions = ?,
 			started_at = ?, completed_at = ?, error_message = ?
 		WHERE id = ?`,
-		t.Status, t.Prompt, t.Plan, t.PlanFeedback,
+		t.Status, t.Title, t.Prompt, t.Plan, t.PlanFeedback,
 		t.RepoURL, t.BaseBranch, t.SourceType,
 		t.GithubOwner, t.GithubRepo, t.GithubIssue,
 		t.SessionID, t.WorkspaceID, t.CurrentStep,
@@ -273,7 +273,7 @@ type scanner interface {
 func scanTask(s scanner) (*Task, error) {
 	var t Task
 	err := s.Scan(
-		&t.ID, &t.Status, &t.Prompt, &t.Plan, &t.PlanFeedback,
+		&t.ID, &t.Status, &t.Title, &t.Prompt, &t.Plan, &t.PlanFeedback,
 		&t.RepoURL, &t.BaseBranch, &t.SourceType,
 		&t.GithubOwner, &t.GithubRepo, &t.GithubIssue,
 		&t.SessionID, &t.WorkspaceID, &t.CurrentStep,

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -87,7 +87,7 @@ export function Dashboard({ subscribe }: DashboardProps) {
                         to={`/tasks/${agent.task_id}`}
                         className="text-sm text-sky-400 hover:underline"
                       >
-                        {agent.task_id.slice(0, 8)}...
+                        {agent.task_title || agent.task_id.slice(0, 8) + "..."}
                       </Link>
                     ) : (
                       <span className="text-sm text-zinc-500">Idle</span>

--- a/web/src/pages/NewTask.tsx
+++ b/web/src/pages/NewTask.tsx
@@ -5,23 +5,21 @@ import { Combobox } from "@/components/ui/combobox"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
-import { createTask, getConfig, listRepositories } from "@/api/client"
+import { createTask, listRepositories } from "@/api/client"
 import type { RepoInfo } from "@/types/api"
 
 export function NewTask() {
   const navigate = useNavigate()
+  const [title, setTitle] = useState("")
   const [prompt, setPrompt] = useState("")
   const [repoUrl, setRepoUrl] = useState("")
   const [baseBranch, setBaseBranch] = useState("main")
-  const [createIssue, setCreateIssue] = useState(false)
   const [repos, setRepos] = useState<RepoInfo[]>([])
   const [reposLoading, setReposLoading] = useState(false)
-  const [githubConfigured, setGithubConfigured] = useState(false)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState("")
 
   useEffect(() => {
-    getConfig().then((c) => setGithubConfigured(c.github_configured)).catch(() => {})
     setReposLoading(true)
     listRepositories()
       .then(setRepos)
@@ -36,10 +34,10 @@ export function NewTask() {
 
     try {
       const task = await createTask({
+        title: title || undefined,
         prompt,
         repo_url: repoUrl,
         base_branch: baseBranch,
-        ...(createIssue && { create_issue: true }),
       })
       navigate(`/tasks/${task.id}`)
     } catch (err) {
@@ -53,6 +51,18 @@ export function NewTask() {
     <div className="mx-auto max-w-2xl">
       <h1 className="mb-6 text-2xl font-semibold text-zinc-100">New Task</h1>
       <form onSubmit={handleSubmit} className="space-y-6">
+        <div className="space-y-2">
+          <Label htmlFor="title">Title</Label>
+          <Input
+            id="title"
+            placeholder="Short summary of the task"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            className="bg-zinc-950 border-zinc-700"
+            required
+          />
+        </div>
+
         <div className="space-y-2">
           <Label htmlFor="prompt">Prompt</Label>
           <Textarea
@@ -88,25 +98,12 @@ export function NewTask() {
           />
         </div>
 
-        {githubConfigured && (
-          <div className="flex items-center gap-2">
-            <input
-              id="create_issue"
-              type="checkbox"
-              checked={createIssue}
-              onChange={(e) => setCreateIssue(e.target.checked)}
-              className="h-4 w-4 rounded border-zinc-700 bg-zinc-950"
-            />
-            <Label htmlFor="create_issue">Create GitHub issue</Label>
-          </div>
-        )}
-
         {error && (
           <p className="text-sm text-red-400">{error}</p>
         )}
 
         <div className="flex gap-3">
-          <Button type="submit" disabled={loading || !prompt || !repoUrl}>
+          <Button type="submit" disabled={loading || !title || !prompt || !repoUrl}>
             {loading ? "Creating..." : "Create Task"}
           </Button>
           <Button

--- a/web/src/pages/TaskDetail.tsx
+++ b/web/src/pages/TaskDetail.tsx
@@ -59,8 +59,11 @@ export function TaskDetail({ subscribe }: TaskDetailProps) {
       <div className="flex items-start justify-between gap-4">
         <div className="min-w-0 flex-1">
           <h1 className="text-2xl font-semibold text-zinc-100 break-words">
-            {task.prompt}
+            {task.title ?? task.prompt}
           </h1>
+          {task.title && (
+            <p className="mt-2 text-sm text-zinc-300 whitespace-pre-wrap">{task.prompt}</p>
+          )}
           <div className="mt-2 flex flex-wrap items-center gap-3 text-sm text-zinc-400">
             <StatusBadge status={task.status} />
             <span>{task.repo_url.replace(/^https?:\/\/github\.com\//, "")}</span>

--- a/web/src/pages/TaskList.tsx
+++ b/web/src/pages/TaskList.tsx
@@ -33,7 +33,7 @@ export function TaskList({ subscribe }: TaskListProps) {
           <TableHeader>
             <TableRow className="border-zinc-800 hover:bg-transparent">
               <TableHead className="text-zinc-400">Status</TableHead>
-              <TableHead className="text-zinc-400">Prompt</TableHead>
+              <TableHead className="text-zinc-400">Title</TableHead>
               <TableHead className="text-zinc-400">Repository</TableHead>
               <TableHead className="text-zinc-400">Source</TableHead>
               <TableHead className="text-zinc-400">Created</TableHead>
@@ -67,9 +67,12 @@ export function TaskList({ subscribe }: TaskListProps) {
                     to={`/tasks/${task.id}`}
                     className="text-sm text-zinc-100 hover:text-sky-400"
                   >
-                    {task.prompt.length > 80
-                      ? task.prompt.slice(0, 80) + "..."
-                      : task.prompt}
+                    {(() => {
+                      const display = task.title ?? task.prompt
+                      return display.length > 80
+                        ? display.slice(0, 80) + "..."
+                        : display
+                    })()}
                   </Link>
                 </TableCell>
                 <TableCell className="text-sm text-zinc-400">

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -1,6 +1,7 @@
 export interface Task {
   id: string
   status: string
+  title: string | null
   prompt: string
   plan: string | null
   plan_feedback: string | null
@@ -37,6 +38,7 @@ export interface TaskLog {
 export interface AgentInfo {
   name: string
   task_id: string
+  task_title: string
   workspace_status: string
 }
 
@@ -47,14 +49,15 @@ export interface WSEvent {
 }
 
 export interface CreateTaskRequest {
+  title?: string
   prompt: string
   repo_url: string
   base_branch: string
-  create_issue?: boolean
 }
 
 export interface ConfigResponse {
   github_configured: boolean
+  auto_create_issues: boolean
 }
 
 export interface RepoInfo {


### PR DESCRIPTION
## Summary
- Adds a `title` field to the Task model (migration 004) used as a short summary for display and GitHub issue titles
- Replaces the opt-in "Create GitHub issue" checkbox with automatic issue creation controlled by `CREATE_GITHUB_ISSUES` env var (defaults to `true`); non-GitHub repos and missing GitHub config silently skip issue creation
- Displays task title in the Dashboard agent table, Tasks list, and Task detail page (falls back to truncated prompt for older tasks without titles)
- Webhook-created tasks automatically populate title from the GitHub issue title
- Exposes `auto_create_issues` in the `/config` endpoint response

## Test plan
- [x] `go test ./...` — all existing and new tests pass
- [x] `cd web && npm run build` — frontend builds without errors
- [ ] Create a task via UI with title + prompt → verify GitHub issue uses title
- [ ] Set `CREATE_GITHUB_ISSUES=false` → verify task created without GitHub issue
- [ ] Verify Dashboard shows task title for active agents
- [ ] Verify Tasks table shows title column
- [ ] Verify tasks created via webhook have title populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)