### PR TITLE
fix: prepend title to prompt in web app task creation

### DIFF
--- a/internal/server/handlers_tasks.go
+++ b/internal/server/handlers_tasks.go
@@ -51,8 +51,13 @@ func (s *Server) handleCreateTask(w http.ResponseWriter, r *http.Request) {
 		req.BaseBranch = "main"
 	}
 
+	prompt := req.Prompt
+	if req.Title != "" {
+		prompt = req.Title + "\n\n" + req.Prompt
+	}
+
 	task := &store.Task{
-		Prompt:     req.Prompt,
+		Prompt:     prompt,
 		RepoURL:    strings.TrimSuffix(req.RepoURL, ".git"),
 		BaseBranch: req.BaseBranch,
 		SourceType: "api",

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -148,6 +148,9 @@ func TestCreateTask_Success(t *testing.T) {
 	if task.Title == nil || *task.Title != "Feature X" {
 		t.Fatalf("expected title 'Feature X', got %v", task.Title)
 	}
+	if task.Prompt != "Feature X\n\nimplement feature X" {
+		t.Fatalf("expected prompt to include title, got %q", task.Prompt)
+	}
 	if task.Status != "queued" {
 		t.Fatalf("expected status 'queued', got %q", task.Status)
 	}
@@ -159,6 +162,32 @@ func TestCreateTask_Success(t *testing.T) {
 	}
 	if task.SessionID == "" {
 		t.Fatal("expected session_id to be set")
+	}
+}
+
+func TestCreateTask_NoTitle_PromptUnchanged(t *testing.T) {
+	srv, s := testServer(t)
+	ts := httptest.NewServer(srv.Routes())
+	defer ts.Close()
+	client := authenticatedClient(t, s, ts.URL)
+
+	body := `{"prompt": "implement feature X", "repo_url": "https://github.com/test/repo"}`
+	resp, err := client.Post(ts.URL+"/api/v1/tasks", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", resp.StatusCode)
+	}
+
+	var task store.Task
+	if err := json.NewDecoder(resp.Body).Decode(&task); err != nil {
+		t.Fatal(err)
+	}
+	if task.Prompt != "implement feature X" {
+		t.Fatalf("expected prompt unchanged without title, got %q", task.Prompt)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Prepends the task title to the prompt (with double newline separator) when creating tasks via the web app API, matching the format used by the GitHub issue webhook flow
- Ensures the orchestrator agent gets consistent context in the `Task: %s` slot regardless of task source
- Adds test coverage for both title-present and no-title cases

## Test plan
- [x] `go test ./...` passes
- [ ] Create a task via the web app with a title and prompt — verify `task.Prompt` includes both
- [ ] Create a task without a title — verify `task.Prompt` is unchanged
- [ ] Compare with a GitHub issue task — prompt format should now match

🤖 Generated with [Claude Code](https://claude.com/claude-code)