### PR TITLE
fix: restrict plan step to read-only tools

### DIFF
--- a/internal/orchestrator/steps.go
+++ b/internal/orchestrator/steps.go
@@ -74,7 +74,7 @@ func (o *Orchestrator) stepPlan(ctx context.Context, task *store.Task, workspace
 		return err
 	}
 	cmd := fmt.Sprintf(
-		"cd %s && TERM=dumb claude --session-id %s -p %s --print",
+		"cd %s && TERM=dumb claude --session-id %s -p %s --print --allowedTools 'Bash,Read,Glob,Grep,Task'",
 		shellQuote(repoDir),
 		shellQuote(task.SessionID),
 		shellQuote(buildPlanPrompt(task)),
@@ -294,7 +294,7 @@ func buildPlanPrompt(task *store.Task) string {
 			"- Use Grep to search for related code, patterns, and existing conventions\n"+
 			"- Use Read to examine key files, interfaces, and functions you will need to modify or extend\n"+
 			"- Use Bash for read-only commands (e.g., git log, ls) to gather additional context\n\n"+
-			"After exploring, output ONLY the implementation plan in markdown. The plan must include:\n\n"+
+			"After exploring, print the complete implementation plan as your final response in markdown — do not write it to any file. The plan must include:\n\n"+
 			"1. **Objective** -- One-sentence restatement of what will be built or changed\n"+
 			"2. **Key Findings** -- What you discovered during exploration that informs the approach "+
 			"(existing patterns to follow, utilities to reuse, constraints found)\n"+


### PR DESCRIPTION
## Summary
- Added `--allowedTools 'Bash,Read,Glob,Grep,Task'` to the `stepPlan` claude command, restricting Claude to read-only tools during planning
- Updated prompt wording from "output ONLY" to "print the complete implementation plan as your final response — do not write it to any file" to remove ambiguity

## Problem
Tasks created via the web app produced significantly worse plans than GitHub issue tasks. The root cause: without tool restrictions, Claude non-deterministically used `Write` to save the plan to a file instead of printing it to stdout. Since `task.Plan` is captured from stdout, only a brief summary was stored.

## Test plan
- [x] `go test ./...` passes
- [ ] Create a task via the web app — verify the plan is detailed (not a summary)
- [ ] Compare with a GitHub issue task — plan quality should now match

🤖 Generated with [Claude Code](https://claude.com/claude-code)