### PR TITLE
fix(ci): use registry cache for release image builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,8 +90,11 @@ jobs:
             ghcr.io/jcwearn/agent-orchestrator:${{ steps.version.outputs.tag }}
             ghcr.io/jcwearn/agent-orchestrator:${{ steps.version.outputs.major_minor }}
             ghcr.io/jcwearn/agent-orchestrator:sha-${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # GHA cache is read-only for pull_request-triggered runs as of
+          # https://github.blog/changelog/2026-06-26-read-only-actions-cache-for-untrusted-triggers/
+          # so release builds cache via the registry instead.
+          cache-from: type=registry,ref=ghcr.io/jcwearn/agent-orchestrator:buildcache
+          cache-to: type=registry,ref=ghcr.io/jcwearn/agent-orchestrator:buildcache,mode=max
 
       - name: Create GitHub Release
         env:


### PR DESCRIPTION
## Problem

Every **Release** workflow run since July 10 has failed at the *Build and push image* step with:

```
ERROR: failed to build: failed to solve: error writing layer blob: failed to reserve cache
```

All 5 recent failures are the same root cause. Per GitHub's [Read-only Actions cache for untrusted triggers](https://github.blog/changelog/2026-06-26-read-only-actions-cache-for-untrusted-triggers/) change (June 26, 2026), `pull_request`-triggered runs now get **read-only** cache tokens for the default-branch cache scope. The last successful run (July 6) shows `refs/heads/main: read/write` in the runtime token ACs; the failing runs show `refs/heads/main: read`. BuildKit's `gha` cache exporter fails hard when it can't reserve a cache entry, so `cache-to: type=gha,mode=max` kills the whole release — the git tag is created but no image is pushed and no GitHub release is made.

The **Build Image** workflow is unaffected because open-PR runs write to their own PR-scoped cache, which still permits writes.

## Fix

Switch the Release build to a registry-backed cache at `ghcr.io/jcwearn/agent-orchestrator:buildcache`. The job already has `packages: write` and is logged into ghcr, so cache writes work regardless of Actions cache token scoping, and release builds keep a warm cache between runs.

## Note

Releases v0.0.169–v0.0.173 created git tags but never published images or GitHub releases. After this merges, those may need backfilling (or the tags can be left as-is and superseded by the next release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)